### PR TITLE
EMCS-262: query parameters for lastUpdated/createdOn

### DIFF
--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMessagesController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMessagesController.scala
@@ -53,9 +53,10 @@ class GetMessagesController @Inject()(
   }
 
   private def getMessagesAsJson(lrn: String, ern: String, lastUpdated: Option[String]): Future[Result] = {
+    val lastUpdatedTime = lastUpdated.map(Instant.parse(_))
     movementService.getMovementByLRNAndERNIn(lrn, List(ern))
       .map(mv => {
-        mv.map(m => filterMessagesByTime(m.messages, lastUpdated))
+        mv.map(m => filterMessagesByTime(m.messages, lastUpdatedTime))
       })
       .map {
       case Some(mv) => Ok(Json.toJson(mv))
@@ -63,9 +64,9 @@ class GetMessagesController @Inject()(
     }
   }
 
-  private def filterMessagesByTime(messages: Seq[Message], updatedSince: Option[String]): Seq[Message] = {
+  private def filterMessagesByTime(messages: Seq[Message], updatedSince: Option[Instant]): Seq[Message] = {
       updatedSince.fold[Seq[Message]](messages)(a =>
-        messages.filter(o => o.createdOn.isAfter(Instant.parse(a)) || o.createdOn.equals(Instant.parse(a)))
+        messages.filter(o => o.createdOn.isAfter(a) || o.createdOn.equals(a))
       )
   }
 

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMessagesController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMessagesController.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.excisemovementcontrolsystemapi.services.{MovementService, Wor
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.EmcsUtils
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
-import java.time.{Instant, LocalDateTime}
+import java.time.Instant
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
@@ -36,13 +36,13 @@ class GetMovementsController @Inject()(
                                       )(implicit ec: ExecutionContext)
   extends BackendController(cc) {
 
-  def getMovements(ern: Option[String], lrn: Option[String], arc: Option[String], lastUpdated: Option[String]): Action[AnyContent] = {
+  def getMovements(ern: Option[String], lrn: Option[String], arc: Option[String], updatedSince: Option[String]): Action[AnyContent] = {
     authAction.async(parse.default) {
       implicit request =>
 
         workItemService.addWorkItemForErn(ern.getOrElse(request.erns.head), fastMode = false)
 
-        val filter = MovementFilter.and(Seq("ern" -> ern, "lrn" -> lrn, "arc" -> arc, "lastUpdated" -> lastUpdated))
+        val filter = MovementFilter.and(Seq("ern" -> ern, "lrn" -> lrn, "arc" -> arc, "updatedSince" -> updatedSince))
         movementService.getMovementByErn(request.erns.toSeq, filter)
           .map { movement: Seq[Movement] =>
             Ok(Json.toJson(movement.map(createResponseFrom)))

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
@@ -36,7 +36,7 @@ class GetMovementsController @Inject()(
                                       )(implicit ec: ExecutionContext)
   extends BackendController(cc) {
 
-  def getMovements(ern: Option[String], lrn: Option[String], arc: Option[String]): Action[AnyContent] = {
+  def getMovements(ern: Option[String], lrn: Option[String], arc: Option[String], updatedSince: Option[String]): Action[AnyContent] = {
     authAction.async(parse.default) {
       implicit request =>
 

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
@@ -20,19 +20,23 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.actions.AuthAction
 import uk.gov.hmrc.excisemovementcontrolsystemapi.filters.MovementFilter
-import uk.gov.hmrc.excisemovementcontrolsystemapi.models.GetMovementResponse
+import uk.gov.hmrc.excisemovementcontrolsystemapi.models.{ErrorResponse, GetMovementResponse}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 import uk.gov.hmrc.excisemovementcontrolsystemapi.services.{MovementService, WorkItemService}
+import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.EmcsUtils
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
+import java.time.Instant
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 class GetMovementsController @Inject()(
                                         authAction: AuthAction,
                                         cc: ControllerComponents,
                                         movementService: MovementService,
-                                        workItemService: WorkItemService
+                                        workItemService: WorkItemService,
+                                        emcsUtils: EmcsUtils
                                       )(implicit ec: ExecutionContext)
   extends BackendController(cc) {
 
@@ -42,11 +46,16 @@ class GetMovementsController @Inject()(
 
         workItemService.addWorkItemForErn(ern.getOrElse(request.erns.head), fastMode = false)
 
-        val filter = MovementFilter.and(Seq("ern" -> ern, "lrn" -> lrn, "arc" -> arc, "updatedSince" -> updatedSince))
-        movementService.getMovementByErn(request.erns.toSeq, filter)
-          .map { movement: Seq[Movement] =>
-            Ok(Json.toJson(movement.map(createResponseFrom)))
-          }
+        Try(updatedSince.map(Instant.parse(_))).map { updatedSinceTime =>
+          println("***** " + updatedSinceTime)
+          val filter = MovementFilter.and(Seq("ern" -> ern, "lrn" -> lrn, "arc" -> arc, "updatedSince" -> updatedSinceTime.map(_.toString())))
+          movementService.getMovementByErn(request.erns.toSeq, filter)
+            .map { movement: Seq[Movement] =>
+              Ok(Json.toJson(movement.map(createResponseFrom)))
+            }
+        }.getOrElse(
+          Future.successful(BadRequest(Json.toJson(ErrorResponse(emcsUtils.getCurrentDateTime, "Invalid date format provided in the updatedSince query parameter", ""))))
+        )
     }
   }
 

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
@@ -47,7 +47,6 @@ class GetMovementsController @Inject()(
         workItemService.addWorkItemForErn(ern.getOrElse(request.erns.head), fastMode = false)
 
         Try(updatedSince.map(Instant.parse(_))).map { updatedSinceTime =>
-          println("***** " + updatedSinceTime)
           val filter = MovementFilter.and(Seq("ern" -> ern, "lrn" -> lrn, "arc" -> arc, "updatedSince" -> updatedSinceTime.map(_.toString())))
           movementService.getMovementByErn(request.erns.toSeq, filter)
             .map { movement: Seq[Movement] =>

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.excisemovementcontrolsystemapi.controllers
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.actions.AuthAction
-import uk.gov.hmrc.excisemovementcontrolsystemapi.filters.MovementFilter
+import uk.gov.hmrc.excisemovementcontrolsystemapi.filters.MovementFilterBuilder
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.{ErrorResponse, GetMovementResponse}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 import uk.gov.hmrc.excisemovementcontrolsystemapi.services.{MovementService, WorkItemService}
@@ -47,7 +47,7 @@ class GetMovementsController @Inject()(
         workItemService.addWorkItemForErn(ern.getOrElse(request.erns.head), fastMode = false)
 
         Try(updatedSince.map(Instant.parse(_))).map { updatedSinceTime =>
-          val filter = MovementFilter.and(Seq("ern" -> ern, "lrn" -> lrn, "arc" -> arc, "updatedSince" -> updatedSinceTime.map(_.toString())))
+          val filter = MovementFilterBuilder().withErn(ern).withLrn(lrn).withArc(arc).withUpdatedSince(updatedSinceTime).build()
           movementService.getMovementByErn(request.erns.toSeq, filter)
             .map { movement: Seq[Movement] =>
               Ok(Json.toJson(movement.map(createResponseFrom)))

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
@@ -43,6 +43,8 @@ class GetMovementsController @Inject()(
         workItemService.addWorkItemForErn(ern.getOrElse(request.erns.head), fastMode = false)
 
         val filter = MovementFilter.and(Seq("ern" -> ern, "lrn" -> lrn, "arc" -> arc, "lastUpdated" -> lastUpdated))
+
+        println("&&&&&&&&& " + filter)
         movementService.getMovementByErn(request.erns.toSeq, filter)
           .map { movement: Seq[Movement] =>
             Ok(Json.toJson(movement.map(createResponseFrom)))

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
@@ -43,8 +43,6 @@ class GetMovementsController @Inject()(
         workItemService.addWorkItemForErn(ern.getOrElse(request.erns.head), fastMode = false)
 
         val filter = MovementFilter.and(Seq("ern" -> ern, "lrn" -> lrn, "arc" -> arc, "lastUpdated" -> lastUpdated))
-
-        println("&&&&&&&&& " + filter)
         movementService.getMovementByErn(request.erns.toSeq, filter)
           .map { movement: Seq[Movement] =>
             Ok(Json.toJson(movement.map(createResponseFrom)))

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
@@ -36,13 +36,13 @@ class GetMovementsController @Inject()(
                                       )(implicit ec: ExecutionContext)
   extends BackendController(cc) {
 
-  def getMovements(ern: Option[String], lrn: Option[String], arc: Option[String], updatedSince: Option[String]): Action[AnyContent] = {
+  def getMovements(ern: Option[String], lrn: Option[String], arc: Option[String], lastUpdated: Option[String]): Action[AnyContent] = {
     authAction.async(parse.default) {
       implicit request =>
 
         workItemService.addWorkItemForErn(ern.getOrElse(request.erns.head), fastMode = false)
 
-        val filter = MovementFilter.and(Seq("ern" -> ern, "lrn" -> lrn, "arc" -> arc))
+        val filter = MovementFilter.and(Seq("ern" -> ern, "lrn" -> lrn, "arc" -> arc, "lastUpdated" -> lastUpdated))
         movementService.getMovementByErn(request.erns.toSeq, filter)
           .map { movement: Seq[Movement] =>
             Ok(Json.toJson(movement.map(createResponseFrom)))

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilter.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilter.scala
@@ -18,6 +18,8 @@ package uk.gov.hmrc.excisemovementcontrolsystemapi.filters
 
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 
+import java.time.Instant
+
 sealed trait Filter {
   def filter(movements: Seq[Movement]): Seq[Movement]
 }
@@ -43,6 +45,13 @@ case class FilterArc(arc: Option[String] = None) extends Filter {
     arc.fold[Seq[Movement]](movements)(a =>
       movements.filter(o => o.administrativeReferenceCode.contains(a))
     )
+  }
+}
+
+case class FilterUpdatedSince(updatedSince: Option[String] = None) extends Filter {
+  def filter(movements: Seq[Movement]): Seq[Movement] = {
+    updatedSince.fold[Seq[Movement]](movements)(a =>
+    movements.filter(o => o.lastUpdated.isAfter(Instant.parse(a))))
   }
 }
 
@@ -75,6 +84,7 @@ object MovementFilter {
             case "ern" => FilterErn(o._2)
             case "lrn" => FilterLrn(o._2)
             case "arc" => FilterArc(o._2)
+            case "lastUpdated" => FilterUpdatedSince(o._2)
             case _ => new FilterNothing
           }
         )

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilter.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilter.scala
@@ -51,7 +51,7 @@ case class FilterArc(arc: Option[String] = None) extends Filter {
 case class FilterUpdatedSince(updatedSince: Option[Instant] = None) extends Filter {
   def filter(movements: Seq[Movement]): Seq[Movement] = {
     updatedSince.fold[Seq[Movement]](movements)(a =>
-    movements.filter(o => o.lastUpdated.isAfter(a)))
+    movements.filter(o => o.lastUpdated.isAfter(a) || o.lastUpdated.equals(a)))
   }
 }
 

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilter.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilter.scala
@@ -48,10 +48,10 @@ case class FilterArc(arc: Option[String] = None) extends Filter {
   }
 }
 
-case class FilterUpdatedSince(updatedSince: Option[String] = None) extends Filter {
+case class FilterUpdatedSince(updatedSince: Option[Instant] = None) extends Filter {
   def filter(movements: Seq[Movement]): Seq[Movement] = {
     updatedSince.fold[Seq[Movement]](movements)(a =>
-    movements.filter(o => o.lastUpdated.isAfter(Instant.parse(a))))
+    movements.filter(o => o.lastUpdated.isAfter(a)))
   }
 }
 
@@ -84,7 +84,7 @@ object MovementFilter {
             case "ern" => FilterErn(o._2)
             case "lrn" => FilterLrn(o._2)
             case "arc" => FilterArc(o._2)
-            case "lastUpdated" => FilterUpdatedSince(o._2)
+            case "lastUpdated" => FilterUpdatedSince(o._2.map(Instant.parse(_)))
             case _ => new FilterNothing
           }
         )

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilter.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilter.scala
@@ -70,26 +70,7 @@ case class MovementFilter (private val filter: Seq[Filter]) {
 }
 
 object MovementFilter {
-
   def empty = MovementFilter(Seq.empty)
-
-  def and(filter: Seq[(String, Option[String])]): MovementFilter = {
-
-    MovementFilter(
-      filter match {
-        case Nil => Seq(FilterNothing)
-        case m@ Seq(_,_*) => m.map (o =>
-          o._1 match {
-            case "ern" => FilterErn(o._2)
-            case "lrn" => FilterLrn(o._2)
-            case "arc" => FilterArc(o._2)
-            case "updatedSince" => FilterUpdatedSince(o._2.map(Instant.parse(_)))
-            case _ => FilterNothing
-          }
-        )
-        case _ => Seq(FilterNothing)
-    })
-  }
 }
 
 case class MovementFilterBuilder(private val filters: Seq[Filter]) {

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilter.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilter.scala
@@ -30,8 +30,8 @@ case class FilterErn(ern: Option[String] = None) extends Filter {
       movements.filter(o => o.consignorId.equals(e))
     )
   }
-
 }
+
 case class FilterLrn(lrn: Option[String] = None) extends Filter {
   def filter(movements: Seq[Movement]): Seq[Movement] = {
     lrn.fold[Seq[Movement]](movements)(l =>
@@ -55,14 +55,13 @@ case class FilterUpdatedSince(updatedSince: Option[Instant] = None) extends Filt
   }
 }
 
-class FilterNothing extends Filter {
+object FilterNothing extends Filter {
   def filter(movements: Seq[Movement]): Seq[Movement] = {
     movements
   }
 }
 
 case class MovementFilter (private val filter: Seq[Filter]) {
-
   def filterMovement(movements: Seq[Movement]): Seq[Movement] = {
     filter.foldLeft[Seq[Movement]](movements) {
       (result, e) => e.filter(result)
@@ -78,17 +77,53 @@ object MovementFilter {
 
     MovementFilter(
       filter match {
-        case Nil => Seq(new FilterNothing)
+        case Nil => Seq(FilterNothing)
         case m@ Seq(_,_*) => m.map (o =>
           o._1 match {
             case "ern" => FilterErn(o._2)
             case "lrn" => FilterLrn(o._2)
             case "arc" => FilterArc(o._2)
             case "updatedSince" => FilterUpdatedSince(o._2.map(Instant.parse(_)))
-            case _ => new FilterNothing
+            case _ => FilterNothing
           }
         )
-        case _ => Seq(new FilterNothing)
+        case _ => Seq(FilterNothing)
     })
+  }
+}
+
+case class MovementFilterBuilder(private val filters: Seq[Filter]) {
+  def withErn(ern: Option[String]): MovementFilterBuilder = {
+    add(FilterErn(ern))
+  }
+
+  def withLrn(lrn: Option[String]): MovementFilterBuilder = {
+    add(FilterLrn(lrn))
+  }
+
+  def withArc(arc: Option[String]): MovementFilterBuilder = {
+    add(FilterArc(arc))
+  }
+
+  def withUpdatedSince(updatedSince: Option[Instant]): MovementFilterBuilder = {
+    add(FilterUpdatedSince(updatedSince))
+  }
+
+  def build(): MovementFilter = {
+    if (filters.isEmpty) {
+      MovementFilter(Seq(FilterNothing))
+    } else {
+      MovementFilter(filters)
+    }
+  }
+
+  private def add(newFilter: Filter): MovementFilterBuilder = {
+    this.copy(filters = filters :+ newFilter)
+  }
+}
+
+object MovementFilterBuilder {
+  def apply(): MovementFilterBuilder = {
+    MovementFilterBuilder(Seq.empty)
   }
 }

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilter.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilter.scala
@@ -84,7 +84,7 @@ object MovementFilter {
             case "ern" => FilterErn(o._2)
             case "lrn" => FilterLrn(o._2)
             case "arc" => FilterArc(o._2)
-            case "lastUpdated" => FilterUpdatedSince(o._2.map(Instant.parse(_)))
+            case "updatedSince" => FilterUpdatedSince(o._2.map(Instant.parse(_)))
             case _ => new FilterNothing
           }
         )

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/model/Movement.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/model/Movement.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model
 
 import play.api.libs.json.{Format, Json, OFormat}
-import uk.gov.hmrc.mongo.TimestampSupport
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 
 import java.time.Instant
@@ -47,9 +46,9 @@ object Message {
   def apply(
              encodedMessage: String,
              messageType: String,
-             dateTimeService: TimestampSupport): Message = {
+             createdOn: Instant): Message = {
 
-    Message(encodedMessage.hashCode(), encodedMessage, messageType, dateTimeService.timestamp())
+    Message(encodedMessage.hashCode(), encodedMessage, messageType, createdOn)
   }
 
   implicit val format: OFormat[Message] = Json.format[Message]

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementService.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementService.scala
@@ -115,7 +115,7 @@ class MovementService @Inject()(
   private def saveDistinctMessage(movement: Movement, newMessage: IEMessage): Future[Boolean] = {
 
     val encodedMessage = emcsUtils.encode(newMessage.toXml.toString)
-    val messages = Seq(Message(encodedMessage, newMessage.messageType, timestampSupport))
+    val messages = Seq(Message(encodedMessage, newMessage.messageType, timestampSupport.timestamp()))
 
     //todo: remove hash from message class. Hash can calculate on the go in here
     val allMessages = (movement.messages ++ messages).distinctBy(_.hash)

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementService.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementService.scala
@@ -91,9 +91,16 @@ class MovementService @Inject()(
                         filter: MovementFilter = MovementFilter.empty
                       ): Future[Seq[Movement]] = {
 
-    movementRepository.getMovementByERN(ern).map {
+    val thing = movementRepository.getMovementByERN(ern).map {
       movements => filter.filterMovement(movements)
     }
+
+    thing.map( t =>
+      println("&*&*&*&*&* " + t.length)
+
+    )
+
+    thing
   }
 
   def updateMovement(message: IEMessage, consignorId: String): Future[Boolean] = {

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementService.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementService.scala
@@ -91,16 +91,9 @@ class MovementService @Inject()(
                         filter: MovementFilter = MovementFilter.empty
                       ): Future[Seq[Movement]] = {
 
-    val thing = movementRepository.getMovementByERN(ern).map {
+    movementRepository.getMovementByERN(ern).map {
       movements => filter.filterMovement(movements)
     }
-
-    thing.map( t =>
-      println("&*&*&*&*&* " + t.length)
-
-    )
-
-    thing
   }
 
   def updateMovement(message: IEMessage, consignorId: String): Future[Boolean] = {

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/utils/MessageFilter.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/utils/MessageFilter.scala
@@ -38,7 +38,7 @@ class MessageFilter @Inject()
       .filter(_.lrnEquals(lrnToFilterBy))
       .map { m =>
         val encodedMessage = emcsUtils.encode(m.toXml.toString())
-        Message(encodedMessage, m.messageType, dateTimeService)
+        Message(encodedMessage, m.messageType, dateTimeService.timestamp())
       }
   }
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,7 +1,7 @@
 # microservice specific routes
 
 POST       /movements                  uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.DraftExciseMovementController.submit
-GET        /movements                  uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.GetMovementsController.getMovements(ern: Option[String], lrn: Option[String], arc: Option[String], updatedSince: Option[String])
+GET        /movements                  uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.GetMovementsController.getMovements(ern: Option[String], lrn: Option[String], arc: Option[String], lastUpdated: Option[String])
 GET        /movements/:lrn/messages    uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.GetMessagesController.getMessagesForMovement(lrn: String)
 POST       /movements/:lrn/messages    uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.SubmitMessageController.submit(lrn: String)
 POST       /traders/pre-validate       uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.PreValidateTraderController.submit

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -2,6 +2,6 @@
 
 POST       /movements                  uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.DraftExciseMovementController.submit
 GET        /movements                  uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.GetMovementsController.getMovements(ern: Option[String], lrn: Option[String], arc: Option[String], lastUpdated: Option[String])
-GET        /movements/:lrn/messages    uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.GetMessagesController.getMessagesForMovement(lrn: String)
+GET        /movements/:lrn/messages    uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.GetMessagesController.getMessagesForMovement(lrn: String, lastUpdated: Option[String])
 POST       /movements/:lrn/messages    uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.SubmitMessageController.submit(lrn: String)
 POST       /traders/pre-validate       uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.PreValidateTraderController.submit

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,7 +1,7 @@
 # microservice specific routes
 
 POST       /movements                  uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.DraftExciseMovementController.submit
-GET        /movements                  uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.GetMovementsController.getMovements(ern: Option[String], lrn: Option[String], arc: Option[String], lastUpdated: Option[String])
-GET        /movements/:lrn/messages    uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.GetMessagesController.getMessagesForMovement(lrn: String, lastUpdated: Option[String])
+GET        /movements                  uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.GetMovementsController.getMovements(ern: Option[String], lrn: Option[String], arc: Option[String], updatedSince: Option[String])
+GET        /movements/:lrn/messages    uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.GetMessagesController.getMessagesForMovement(lrn: String, updatedSince: Option[String])
 POST       /movements/:lrn/messages    uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.SubmitMessageController.submit(lrn: String)
 POST       /traders/pre-validate       uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.PreValidateTraderController.submit

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,7 +1,7 @@
 # microservice specific routes
 
 POST       /movements                  uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.DraftExciseMovementController.submit
-GET        /movements                  uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.GetMovementsController.getMovements(ern: Option[String], lrn: Option[String], arc: Option[String])
+GET        /movements                  uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.GetMovementsController.getMovements(ern: Option[String], lrn: Option[String], arc: Option[String], updatedSince: Option[String])
 GET        /movements/:lrn/messages    uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.GetMessagesController.getMessagesForMovement(lrn: String)
 POST       /movements/:lrn/messages    uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.SubmitMessageController.submit(lrn: String)
 POST       /traders/pre-validate       uk.gov.hmrc.excisemovementcontrolsystemapi.controllers.PreValidateTraderController.submit

--- a/it/uk/gov/hmrc/excisemovementcontrolsystemapi/GetMessagesControllerItSpec.scala
+++ b/it/uk/gov/hmrc/excisemovementcontrolsystemapi/GetMessagesControllerItSpec.scala
@@ -42,7 +42,6 @@ import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.{Message, Mov
 import uk.gov.hmrc.mongo.TimestampSupport
 
 import java.nio.charset.StandardCharsets
-import java.time.temporal.ChronoUnit
 import java.time.{Instant, LocalDateTime}
 import java.util.Base64
 import scala.concurrent.{ExecutionContext, Future}
@@ -63,7 +62,7 @@ class GetMessagesControllerItSpec extends PlaySpec
   private val lrn = "token"
   private val url = s"http://localhost:$port/movements/$lrn/messages"
   private lazy val dateTimeService: TimestampSupport = mock[TimestampSupport]
-  private val timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS)
+  private val timestamp = Instant.now()
   private val responseFromEis = EISConsumptionResponse(
     LocalDateTime.of(2023, 1, 2, 3, 4, 5),
     consignorId,

--- a/it/uk/gov/hmrc/excisemovementcontrolsystemapi/GetMovementsControllerItSpec.scala
+++ b/it/uk/gov/hmrc/excisemovementcontrolsystemapi/GetMovementsControllerItSpec.scala
@@ -38,7 +38,6 @@ import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.MovementRepository
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 import uk.gov.hmrc.mongo.TimestampSupport
 
-import java.time.temporal.ChronoUnit
 import java.time.{LocalDateTime, ZoneOffset}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -58,9 +57,8 @@ class GetMovementsControllerItSpec extends PlaySpec
   private val lrn = "token"
   private val url = s"http://localhost:$port/movements"
   private lazy val dateTimeService: TimestampSupport = mock[TimestampSupport]
-  private val timestampNow = LocalDateTime.now().toInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
-  private val timestampTwoDaysAgo = LocalDateTime.now().minusDays(2).toInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
-//  private val timestamp = Instant.parse("2018-11-30T18:35:24.00Z")
+  private val timestampNow = LocalDateTime.now().toInstant(ZoneOffset.UTC)
+  private val timestampTwoDaysAgo = LocalDateTime.now().minusDays(2).toInstant(ZoneOffset.UTC)
 
   private val movement1 = Movement(lrn, consignorId, Some("consigneeId"), Some("arc1"), timestampNow)
   private val movement2 = Movement("lrn1", consignorId, Some("consigneeId"), Some("arc2"), timestampTwoDaysAgo)
@@ -145,7 +143,7 @@ class GetMovementsControllerItSpec extends PlaySpec
     }
 
     "get filtered movement by lastUpdated" in {
-      val timeFilter = LocalDateTime.now().minusDays(1).toInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
+      val timeFilter = LocalDateTime.now().minusDays(1).toInstant(ZoneOffset.UTC)
 
       withAuthorizedTrader(consignorId)
       when(movementRepository.getMovementByERN(Seq(consignorId)))

--- a/it/uk/gov/hmrc/excisemovementcontrolsystemapi/GetMovementsControllerItSpec.scala
+++ b/it/uk/gov/hmrc/excisemovementcontrolsystemapi/GetMovementsControllerItSpec.scala
@@ -142,14 +142,14 @@ class GetMovementsControllerItSpec extends PlaySpec
       )
     }
 
-    "get filtered movement by lastUpdated" in {
+    "get filtered movement by updatedSince" in {
       val timeFilter = LocalDateTime.now().minusDays(1).toInstant(ZoneOffset.UTC)
 
       withAuthorizedTrader(consignorId)
       when(movementRepository.getMovementByERN(Seq(consignorId)))
         .thenReturn(Future.successful(Seq(movement1, movement2, movement3)))
 
-      val urlToGoIn = s"$url?lastUpdated=$timeFilter"
+      val urlToGoIn = s"$url?updatedSince=$timeFilter"
 
       val result = getRequest(urlToGoIn)
 

--- a/it/uk/gov/hmrc/excisemovementcontrolsystemapi/GetMovementsControllerItSpec.scala
+++ b/it/uk/gov/hmrc/excisemovementcontrolsystemapi/GetMovementsControllerItSpec.scala
@@ -38,7 +38,8 @@ import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.MovementRepository
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 import uk.gov.hmrc.mongo.TimestampSupport
 
-import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.time.{LocalDateTime, ZoneOffset}
 import scala.concurrent.{ExecutionContext, Future}
 
 class GetMovementsControllerItSpec extends PlaySpec
@@ -57,11 +58,13 @@ class GetMovementsControllerItSpec extends PlaySpec
   private val lrn = "token"
   private val url = s"http://localhost:$port/movements"
   private lazy val dateTimeService: TimestampSupport = mock[TimestampSupport]
-  private val timestamp = Instant.parse("2018-11-30T18:35:24.00Z")
+  private val timestampNow = LocalDateTime.now().toInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
+  private val timestampTwoDaysAgo = LocalDateTime.now().minusDays(2).toInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
+//  private val timestamp = Instant.parse("2018-11-30T18:35:24.00Z")
 
-  private val movement1 = Movement(lrn, consignorId, Some("consigneeId"), Some("arc1"), timestamp)
-  private val movement2 = Movement("lrn1", consignorId, Some("consigneeId"), Some("arc2"), timestamp)
-  private val movement3 = Movement("lrn2", "ern2", Some("consigneeId"), Some("arc3"), timestamp)
+  private val movement1 = Movement(lrn, consignorId, Some("consigneeId"), Some("arc1"), timestampNow)
+  private val movement2 = Movement("lrn1", consignorId, Some("consigneeId"), Some("arc2"), timestampTwoDaysAgo)
+  private val movement3 = Movement("lrn2", "ern2", Some("consigneeId"), Some("arc3"), timestampTwoDaysAgo)
 
   override lazy val app: Application = {
     wireMock.start()
@@ -138,6 +141,26 @@ class GetMovementsControllerItSpec extends PlaySpec
 
       result.json mustBe Json.toJson(Seq(
         createMovementResponse(consignorId,lrn, "arc1", Some("consigneeId")))
+      )
+    }
+
+    "get filtered movement by lastUpdated" in {
+      val timeFilter = LocalDateTime.now().minusDays(1).toInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
+
+      println("***************" + timeFilter)
+
+      withAuthorizedTrader(consignorId)
+      when(movementRepository.getMovementByERN(Seq(consignorId)))
+        .thenReturn(Future.successful(Seq(movement1, movement2, movement3)))
+
+      val urlToGoIn = s"$url?lastUpdated=$timeFilter"
+
+      println("^^^^^ " + urlToGoIn)
+
+      val result = getRequest(urlToGoIn)
+
+      result.json mustBe Json.toJson(Seq(
+        createMovementResponse(consignorId, lrn, "arc1", Some("consigneeId")))
       )
     }
 

--- a/it/uk/gov/hmrc/excisemovementcontrolsystemapi/GetMovementsControllerItSpec.scala
+++ b/it/uk/gov/hmrc/excisemovementcontrolsystemapi/GetMovementsControllerItSpec.scala
@@ -147,15 +147,11 @@ class GetMovementsControllerItSpec extends PlaySpec
     "get filtered movement by lastUpdated" in {
       val timeFilter = LocalDateTime.now().minusDays(1).toInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS)
 
-      println("***************" + timeFilter)
-
       withAuthorizedTrader(consignorId)
       when(movementRepository.getMovementByERN(Seq(consignorId)))
         .thenReturn(Future.successful(Seq(movement1, movement2, movement3)))
 
       val urlToGoIn = s"$url?lastUpdated=$timeFilter"
-
-      println("^^^^^ " + urlToGoIn)
 
       val result = getRequest(urlToGoIn)
 

--- a/it/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
+++ b/it/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
@@ -98,7 +98,7 @@ class MovementRepositoryItSpec extends PlaySpec
       insertMovement(Movement("1", "345", Some("789"), None, timestamp))
       insertMovement(Movement("2", "897", Some("456"), None))
 
-      val message = Message("any, message", MessageTypes.IE801.value, dateTimeService)
+      val message = Message("any, message", MessageTypes.IE801.value, dateTimeService.timestamp())
       val result = repository.updateMovement(Movement("2", "897", Some("321"), Some("arc"), Instant.now, Seq(message))).futureValue
 
       val records = findAll().futureValue
@@ -114,7 +114,7 @@ class MovementRepositoryItSpec extends PlaySpec
       insertMovement(Movement("1", "345", Some("789"), None, timestamp))
       insertMovement(Movement("2", "897", Some("456"), None))
 
-      val message = Message("any, message", MessageTypes.IE801.value, dateTimeService)
+      val message = Message("any, message", MessageTypes.IE801.value, dateTimeService.timestamp())
       val result = repository.updateMovement(Movement("2", "78", Some("456"), Some("arc"), Instant.now, Seq(message))).futureValue
 
       val records = findAll().futureValue
@@ -131,7 +131,7 @@ class MovementRepositoryItSpec extends PlaySpec
       insertMovement(Movement("1", "345", Some("789"), None, instant))
       insertMovement(Movement("2", "897", Some("456"), None, instant))
 
-      val message = Message("any, message", MessageTypes.IE801.value, dateTimeService)
+      val message = Message("any, message", MessageTypes.IE801.value, dateTimeService.timestamp())
       val result = repository.updateMovement(Movement("4", "897", Some("321"), Some("arc"), Instant.now, Seq(message))).futureValue
 
       val records = findAll().futureValue

--- a/it/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/PollingNewMessagesWithWorkItemJobItSpec.scala
+++ b/it/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/PollingNewMessagesWithWorkItemJobItSpec.scala
@@ -442,7 +442,7 @@ class PollingNewMessagesWithWorkItemJobItSpec extends PlaySpec
     Message(
       Base64.getEncoder.encodeToString(xml.getBytes(StandardCharsets.UTF_8)),
       messageType,
-      timeService
+      timeService.timestamp()
     )
   }
 }

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMessagesControllerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMessagesControllerSpec.scala
@@ -35,7 +35,6 @@ import uk.gov.hmrc.excisemovementcontrolsystemapi.services.{MovementService, Wor
 import uk.gov.hmrc.mongo.TimestampSupport
 
 import java.time.Instant
-import java.time.temporal.ChronoUnit
 import scala.concurrent.{ExecutionContext, Future}
 
 class GetMessagesControllerSpec extends PlaySpec
@@ -96,7 +95,8 @@ class GetMessagesControllerSpec extends PlaySpec
     }
 
     "get all the new messages when there is a time query parameter provided" in {
-      val timeNow = dateTimeService.timestamp().truncatedTo(ChronoUnit.SECONDS).toString
+      val timeNow = dateTimeService.timestamp()
+        .toString
       val timeInFuture = Instant.now.plusSeconds(1000)
       val timeInPast = Instant.now.minusSeconds(1000)
       val message = Message("message", "IE801", timeInFuture)
@@ -112,7 +112,7 @@ class GetMessagesControllerSpec extends PlaySpec
     }
 
     "get all the new messages including messages with a createdOn time of NOW when there is a time query parameter provided" in {
-      val timeNow = dateTimeService.timestamp()//.truncatedTo(ChronoUnit.SECONDS)
+      val timeNow = dateTimeService.timestamp()
 
       //TODO: do we need to do this truncated stuff everywhere? Or even at all. Just make sure that the format we have
       // specified is adhered to

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsControllerSpec.scala
@@ -26,7 +26,7 @@ import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{await, contentAsJson, defaultAwaitTimeout, status, stubControllerComponents}
-import uk.gov.hmrc.excisemovementcontrolsystemapi.filters.MovementFilter
+import uk.gov.hmrc.excisemovementcontrolsystemapi.filters.{MovementFilter, MovementFilterBuilder}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.fixture.{FakeAuthentication, MovementTestUtils}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.ErrorResponse
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
@@ -95,12 +95,13 @@ class GetMovementsControllerSpec
 
     "use a filter" in {
       val timestampNow = LocalDateTime.now().toInstant(ZoneOffset.UTC)
-        .toString
-      await(controller.getMovements(Some(ern), Some("lrn"), Some("arc"), Some(timestampNow))(FakeRequest("POST", "/foo")))
+      await(controller.getMovements(Some(ern), Some("lrn"), Some("arc"), Some(timestampNow.toString))(FakeRequest("POST", "/foo")))
 
-      val filter = MovementFilter.and(Seq(
-        "ern" -> Some(ern), "lrn" -> Some("lrn"), "arc" -> Some("arc"), "updatedSince" -> Some(timestampNow))
-      )
+      val filter = MovementFilterBuilder()
+        .withErn(Some(ern))
+        .withLrn(Some("lrn"))
+        .withArc(Some("arc"))
+        .withUpdatedSince(Some(timestampNow)).build()
       verify(movementService).getMovementByErn(any, eqTo(filter))
 
     }

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsControllerSpec.scala
@@ -31,7 +31,6 @@ import uk.gov.hmrc.excisemovementcontrolsystemapi.fixture.{FakeAuthentication, M
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 import uk.gov.hmrc.excisemovementcontrolsystemapi.services.{MovementService, WorkItemService}
 
-import java.time.temporal.ChronoUnit
 import java.time.{LocalDateTime, ZoneOffset}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -88,7 +87,8 @@ class GetMovementsControllerSpec
     }
 
     "use a filter" in {
-      val timestampNow = LocalDateTime.now().toInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS).toString
+      val timestampNow = LocalDateTime.now().toInstant(ZoneOffset.UTC)
+        .toString
       await(controller.getMovements(Some(ern), Some("lrn"), Some("arc"), Some(timestampNow))(FakeRequest("POST", "/foo")))
 
       val filter = MovementFilter.and(Seq(

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsControllerSpec.scala
@@ -92,7 +92,7 @@ class GetMovementsControllerSpec
       await(controller.getMovements(Some(ern), Some("lrn"), Some("arc"), Some(timestampNow))(FakeRequest("POST", "/foo")))
 
       val filter = MovementFilter.and(Seq(
-        "ern" -> Some(ern), "lrn" -> Some("lrn"), "arc" -> Some("arc"), "lastUpdated" -> Some(timestampNow))
+        "ern" -> Some(ern), "lrn" -> Some("lrn"), "arc" -> Some("arc"), "updatedSince" -> Some(timestampNow))
       )
       verify(movementService).getMovementByErn(any, eqTo(filter))
 

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsControllerSpec.scala
@@ -58,14 +58,14 @@ class GetMovementsControllerSpec
 
   "getMovements" should {
     "return 200 when successful" in {
-      val result = controller.getMovements(None, None, None)(FakeRequest("POST", "/foo"))
+      val result = controller.getMovements(None, None, None, None)(FakeRequest("POST", "/foo"))
 
       status(result) mustBe OK
       contentAsJson(result) mustBe Json.toJson(Seq(createMovementResponse(ern, "lrn", "arc", Some("consigneeId"))))
     }
 
     "get all movement for an ERN" in {
-      await(controller.getMovements(None, None, None)(FakeRequest("GET", "/foo")))
+      await(controller.getMovements(None, None, None, None)(FakeRequest("GET", "/foo")))
 
       verify(movementService).getMovementByErn(eqTo(Seq(ern)), any)
     }
@@ -76,7 +76,7 @@ class GetMovementsControllerSpec
       when(movementService.getMovementByErn(any, any))
         .thenReturn(Future.successful(Seq(movement1, movement2)))
 
-      val result = controller.getMovements(None, None, None)(FakeRequest("POST", "/foo"))
+      val result = controller.getMovements(None, None, None, None)(FakeRequest("POST", "/foo"))
 
       status(result) mustBe OK
       contentAsJson(result) mustBe Json.toJson(Seq(
@@ -86,7 +86,7 @@ class GetMovementsControllerSpec
     }
 
     "use a filter" in {
-      await(controller.getMovements(Some(ern), Some("lrn"), Some("arc"))(FakeRequest("POST", "/foo")))
+      await(controller.getMovements(Some(ern), Some("lrn"), Some("arc"), None)(FakeRequest("POST", "/foo")))
 
       val filter = MovementFilter.and(Seq(
         "ern" -> Some(ern), "lrn" -> Some("lrn"), "arc" -> Some("arc"))

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsControllerSpec.scala
@@ -31,7 +31,8 @@ import uk.gov.hmrc.excisemovementcontrolsystemapi.fixture.{FakeAuthentication, M
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 import uk.gov.hmrc.excisemovementcontrolsystemapi.services.{MovementService, WorkItemService}
 
-import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import java.time.{LocalDateTime, ZoneOffset}
 import scala.concurrent.{ExecutionContext, Future}
 
 class GetMovementsControllerSpec
@@ -87,11 +88,11 @@ class GetMovementsControllerSpec
     }
 
     "use a filter" in {
-      val timeFilter = LocalDateTime.now().toString
-      await(controller.getMovements(Some(ern), Some("lrn"), Some("arc"), Some(timeFilter))(FakeRequest("POST", "/foo")))
+      val timestampNow = LocalDateTime.now().toInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS).toString
+      await(controller.getMovements(Some(ern), Some("lrn"), Some("arc"), Some(timestampNow))(FakeRequest("POST", "/foo")))
 
       val filter = MovementFilter.and(Seq(
-        "ern" -> Some(ern), "lrn" -> Some("lrn"), "arc" -> Some("arc"), "lastUpdated" -> Some(timeFilter))
+        "ern" -> Some(ern), "lrn" -> Some("lrn"), "arc" -> Some("arc"), "lastUpdated" -> Some(timestampNow))
       )
       verify(movementService).getMovementByErn(any, eqTo(filter))
 

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/SubmitMessageControllerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/SubmitMessageControllerSpec.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.excisemovementcontrolsystemapi.controllers
 
-import org.bson.types.ObjectId
 import org.mockito.ArgumentMatchersSugar.any
 import org.mockito.MockitoSugar.{reset, verify, when}
 import org.mongodb.scala.MongoException
@@ -32,13 +31,9 @@ import uk.gov.hmrc.excisemovementcontrolsystemapi.data.TestXml
 import uk.gov.hmrc.excisemovementcontrolsystemapi.fixture.{FakeAuthentication, FakeValidateErnsAction, FakeValidateLRNAction, FakeXmlParsers}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.eis.EISSubmissionResponse
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.messages.IEMessage
-import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.ExciseNumberWorkItem
 import uk.gov.hmrc.excisemovementcontrolsystemapi.services.WorkItemService
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.EmcsUtils
-import uk.gov.hmrc.mongo.workitem.ProcessingStatus.ToDo
-import uk.gov.hmrc.mongo.workitem.WorkItem
 
-import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.Elem
 

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilterSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilterSpec.scala
@@ -54,24 +54,24 @@ class MovementFilterSpec extends PlaySpec {
       filter.filterMovement(movements) mustBe Seq(m1)
     }
 
-    "filter by lastUpdated" in {
-      val filter = MovementFilter.and(Seq("lastUpdated" -> Some(now.plusSeconds(700).toString())))
+    "filter by updatedSince" in {
+      val filter = MovementFilter.and(Seq("updatedSince" -> Some(now.plusSeconds(700).toString())))
 
       filter.filterMovement(movements) mustBe Seq(m2)
     }
 
-    "filter by lastUpdated and include movements with a lastUpdated time that equals the filter time" in {
-      val filter = MovementFilter.and(Seq("lastUpdated" -> Some(now.plusSeconds(500).toString())))
+    "filter by updatedSince and include movements with a updatedSince time that equals the filter time" in {
+      val filter = MovementFilter.and(Seq("updatedSince" -> Some(now.plusSeconds(500).toString())))
 
       filter.filterMovement(movements) mustBe Seq(m1, m2)
     }
 
-    "filter by ERN, LRN, ARC and lastUpdated" in {
+    "filter by ERN, LRN, ARC and updatedSince" in {
       val filter = MovementFilter.and(Seq(
         "lrn" -> Some("2"),
         "ern" -> Some("test2"),
         "arc" -> Some("arc2"),
-        "lastUpdated" -> Some(now.toString())
+        "updatedSince" -> Some(now.toString())
       ))
 
       filter.filterMovement(movements) mustBe Seq(m2)
@@ -117,7 +117,7 @@ class MovementFilterSpec extends PlaySpec {
     }
 
     "there is no filter" in {
-      val filter = MovementFilter.and(Seq("ern" -> None, "lrn" -> None, "arc" -> None, "lastUpdated" -> None))
+      val filter = MovementFilter.and(Seq("ern" -> None, "lrn" -> None, "arc" -> None, "updatedSince" -> None))
 
       filter.filterMovement(movements) mustBe movements
     }
@@ -129,14 +129,14 @@ class MovementFilterSpec extends PlaySpec {
     }
 
     "succeed when a valid date format is provided" in {
-      val filter = MovementFilter.and(Seq("lastUpdated" -> Some("2020-11-15T17:02:34.00Z")))
+      val filter = MovementFilter.and(Seq("updatedSince" -> Some("2020-11-15T17:02:34.00Z")))
 
       filter.filterMovement(movements) mustBe Seq(m1, m2, m3, m4, m5)
     }
 
     "fail when an invalid date format is provided" in {
       intercept[DateTimeParseException] {
-        val filter = MovementFilter.and(Seq("lastUpdated" -> Some("invalidDate")))
+        val filter = MovementFilter.and(Seq("updatedSince" -> Some("invalidDate")))
         filter.filterMovement(movements)
       }.getMessage mustBe "Text 'invalidDate' could not be parsed at index 0"
     }

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilterSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilterSpec.scala
@@ -20,6 +20,7 @@ import org.scalatestplus.play.PlaySpec
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 
 import java.time.Instant
+import java.time.format.DateTimeParseException
 
 class MovementFilterSpec extends PlaySpec {
 
@@ -126,5 +127,19 @@ class MovementFilterSpec extends PlaySpec {
 
       filter.filterMovement(movements) mustBe movements
     }
+
+    "succeed when a valid date format is provided" in {
+      val filter = MovementFilter.and(Seq("lastUpdated" -> Some("2020-11-15T17:02:34.00Z")))
+
+      filter.filterMovement(movements) mustBe Seq(m1, m2, m3, m4, m5)
+    }
+
+    "fail when an invalid date format is provided" in {
+      intercept[DateTimeParseException] {
+        val filter = MovementFilter.and(Seq("lastUpdated" -> Some("invalidDate")))
+        filter.filterMovement(movements)
+      }.getMessage mustBe "Text 'invalidDate' could not be parsed at index 0"
+    }
+
   }
 }

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilterSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilterSpec.scala
@@ -20,7 +20,6 @@ import org.scalatestplus.play.PlaySpec
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 
 import java.time.Instant
-import java.time.format.DateTimeParseException
 
 class MovementFilterSpec extends PlaySpec {
 
@@ -37,80 +36,66 @@ class MovementFilterSpec extends PlaySpec {
 
   "filterMovement" should {
     "filter by LRN" in {
-      val filter = MovementFilter.and(Seq("lrn" -> Some("lrn3")))
+      val filter = MovementFilterBuilder().withErn(None).withLrn(Some("lrn3")).withArc(None).withUpdatedSince(None).build()
 
       filter.filterMovement(movements) mustBe Seq(m1)
     }
 
     "filter by ERN" in {
-      val filter = MovementFilter.and(Seq("ern" -> Some("test1")))
+      val filter = MovementFilterBuilder().withErn(Some("test1")).withLrn(None).withArc(None).withUpdatedSince(None).build()
 
       filter.filterMovement(movements) mustBe Seq(m1)
     }
 
     "filter by ARC" in {
-      val filter = MovementFilter.and(Seq("arc" -> Some("arc1")))
+      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(Some("arc1")).withUpdatedSince(None).build()
 
       filter.filterMovement(movements) mustBe Seq(m1)
     }
 
     "filter by updatedSince" in {
-      val filter = MovementFilter.and(Seq("updatedSince" -> Some(now.plusSeconds(700).toString())))
+      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(None).withUpdatedSince(Some(now.plusSeconds(700))).build()
 
       filter.filterMovement(movements) mustBe Seq(m2)
     }
 
     "filter by updatedSince and include movements with a updatedSince time that equals the filter time" in {
-      val filter = MovementFilter.and(Seq("updatedSince" -> Some(now.plusSeconds(500).toString())))
+      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(None).withUpdatedSince(Some(now.plusSeconds(500))).build()
 
       filter.filterMovement(movements) mustBe Seq(m1, m2)
     }
 
     "filter by ERN, LRN, ARC and updatedSince" in {
-      val filter = MovementFilter.and(Seq(
-        "lrn" -> Some("2"),
-        "ern" -> Some("test2"),
-        "arc" -> Some("arc2"),
-        "updatedSince" -> Some(now.toString())
-      ))
+      val filter = MovementFilterBuilder()
+        .withErn(Some("test2"))
+        .withLrn(Some("2"))
+        .withArc(Some("arc2"))
+        .withUpdatedSince(Some(now)).build()
 
       filter.filterMovement(movements) mustBe Seq(m2)
     }
 
     "filter by ERN and LRN" in {
-      val filter = MovementFilter.and(Seq(
-        "lrn" -> Some("2"),
-        "ern" -> Some("test2")
-      ))
+      val filter = MovementFilterBuilder().withErn(Some("test2")).withLrn(Some("2")).withArc(None).withUpdatedSince(None).build()
 
       filter.filterMovement(movements) mustBe Seq(m2)
     }
 
     "not return any match for an LRN" in {
-
-      val filter = MovementFilter.and(Seq(
-        "ern" -> None,
-        "lrn" -> Some("3"),
-        "arc" -> Some("arc3")
-      ))
+      val filter = MovementFilterBuilder().withErn(None).withLrn(Some("3")).withArc(Some("arc3")).withUpdatedSince(None).build()
 
       filter.filterMovement(movements) mustBe Seq.empty
     }
 
     "not return any match for an ARC" in {
-
-      val filter = MovementFilter.and(Seq(
-        "ern" -> None,
-        "lrn" -> None,
-        "arc" -> Some("3")
-      ))
+      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(Some("3")).withUpdatedSince(None).build()
 
       filter.filterMovement(movements) mustBe Seq.empty
     }
 
     "not filter" when {
-      "empty sequence" in {
-        val filter = MovementFilter.and(Seq.empty)
+      "empty builder" in {
+        val filter = MovementFilterBuilder().build()
 
         filter.filterMovement(movements) mustBe movements
       }
@@ -128,18 +113,22 @@ class MovementFilterSpec extends PlaySpec {
       filter.filterMovement(movements) mustBe movements
     }
 
-    "succeed when a valid date format is provided" in {
-      val filter = MovementFilter.and(Seq("updatedSince" -> Some("2020-11-15T17:02:34.00Z")))
-
-      filter.filterMovement(movements) mustBe Seq(m1, m2, m3, m4, m5)
-    }
-
-    "fail when an invalid date format is provided" in {
-      intercept[DateTimeParseException] {
-        val filter = MovementFilter.and(Seq("updatedSince" -> Some("invalidDate")))
-        filter.filterMovement(movements)
-      }.getMessage mustBe "Text 'invalidDate' could not be parsed at index 0"
-    }
+//    "succeed when a valid date format is provided" in {
+//      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(None).withUpdatedSince(None).build()
+//
+//      val filter = MovementFilter.and(Seq("updatedSince" -> Some("2020-11-15T17:02:34.00Z")))
+//
+//      filter.filterMovement(movements) mustBe Seq(m1, m2, m3, m4, m5)
+//    }
+//
+//    "fail when an invalid date format is provided" in {
+//      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(None).withUpdatedSince(None).build()
+//
+//      intercept[DateTimeParseException] {
+//        val filter = MovementFilter.and(Seq("updatedSince" -> Some("invalidDate")))
+//        filter.filterMovement(movements)
+//      }.getMessage mustBe "Text 'invalidDate' could not be parsed at index 0"
+//    }
 
   }
 }

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilterSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilterSpec.scala
@@ -36,31 +36,31 @@ class MovementFilterSpec extends PlaySpec {
 
   "filterMovement" should {
     "filter by LRN" in {
-      val filter = MovementFilterBuilder().withErn(None).withLrn(Some("lrn3")).withArc(None).withUpdatedSince(None).build()
+      val filter = MovementFilterBuilder().withLrn(Some("lrn3")).build()
 
       filter.filterMovement(movements) mustBe Seq(m1)
     }
 
     "filter by ERN" in {
-      val filter = MovementFilterBuilder().withErn(Some("test1")).withLrn(None).withArc(None).withUpdatedSince(None).build()
+      val filter = MovementFilterBuilder().withErn(Some("test1")).build()
 
       filter.filterMovement(movements) mustBe Seq(m1)
     }
 
     "filter by ARC" in {
-      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(Some("arc1")).withUpdatedSince(None).build()
+      val filter = MovementFilterBuilder().withArc(Some("arc1")).build()
 
       filter.filterMovement(movements) mustBe Seq(m1)
     }
 
     "filter by updatedSince" in {
-      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(None).withUpdatedSince(Some(now.plusSeconds(700))).build()
+      val filter = MovementFilterBuilder().withUpdatedSince(Some(now.plusSeconds(700))).build()
 
       filter.filterMovement(movements) mustBe Seq(m2)
     }
 
     "filter by updatedSince and include movements with a updatedSince time that equals the filter time" in {
-      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(None).withUpdatedSince(Some(now.plusSeconds(500))).build()
+      val filter = MovementFilterBuilder().withUpdatedSince(Some(now.plusSeconds(500))).build()
 
       filter.filterMovement(movements) mustBe Seq(m1, m2)
     }
@@ -76,19 +76,19 @@ class MovementFilterSpec extends PlaySpec {
     }
 
     "filter by ERN and LRN" in {
-      val filter = MovementFilterBuilder().withErn(Some("test2")).withLrn(Some("2")).withArc(None).withUpdatedSince(None).build()
+      val filter = MovementFilterBuilder().withErn(Some("test2")).withLrn(Some("2")).build()
 
       filter.filterMovement(movements) mustBe Seq(m2)
     }
 
     "not return any match for an LRN" in {
-      val filter = MovementFilterBuilder().withErn(None).withLrn(Some("3")).withArc(Some("arc3")).withUpdatedSince(None).build()
+      val filter = MovementFilterBuilder().withLrn(Some("3")).withArc(Some("arc3")).build()
 
       filter.filterMovement(movements) mustBe Seq.empty
     }
 
     "not return any match for an ARC" in {
-      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(Some("3")).withUpdatedSince(None).build()
+      val filter = MovementFilterBuilder().withArc(Some("3")).build()
 
       filter.filterMovement(movements) mustBe Seq.empty
     }
@@ -112,23 +112,5 @@ class MovementFilterSpec extends PlaySpec {
 
       filter.filterMovement(movements) mustBe movements
     }
-
-//    "succeed when a valid date format is provided" in {
-//      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(None).withUpdatedSince(None).build()
-//
-//      val filter = MovementFilter.and(Seq("updatedSince" -> Some("2020-11-15T17:02:34.00Z")))
-//
-//      filter.filterMovement(movements) mustBe Seq(m1, m2, m3, m4, m5)
-//    }
-//
-//    "fail when an invalid date format is provided" in {
-//      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(None).withUpdatedSince(None).build()
-//
-//      intercept[DateTimeParseException] {
-//        val filter = MovementFilter.and(Seq("updatedSince" -> Some("invalidDate")))
-//        filter.filterMovement(movements)
-//      }.getMessage mustBe "Text 'invalidDate' could not be parsed at index 0"
-//    }
-
   }
 }

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilterSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilterSpec.scala
@@ -117,7 +117,7 @@ class MovementFilterSpec extends PlaySpec {
     }
 
     "there is no filter" in {
-      val filter = MovementFilter.and(Seq("ern" -> None, "lrn" -> None, "arc" -> None, "updatedSince" -> None))
+      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(None).withUpdatedSince(None).build()
 
       filter.filterMovement(movements) mustBe movements
     }

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilterSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilterSpec.scala
@@ -19,13 +19,15 @@ package uk.gov.hmrc.excisemovementcontrolsystemapi.filters
 import org.scalatestplus.play.PlaySpec
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 
+import java.time.Instant
+
 class MovementFilterSpec extends PlaySpec {
 
-  private val m1 = Movement("lrn3", "test1", Some("consigneeId"), Some("arc1"))
-  private val m2 = Movement("2", "test2", Some("consigneeId2"), Some("arc2"))
-  private val m3 = Movement("5", "test2", Some("consigneeId2"), Some("arc3"))
-  private val m4 = Movement("2", "test4", Some("consigneeId2"), Some("arc4"))
-  private val m5 = Movement("lrn345", "test2abc", Some("consigneeId2"), Some("arc3fgn"))
+  private val m1 = Movement("lrn3", "test1", Some("consigneeId"), Some("arc1"), Instant.now.plusSeconds(1000))
+  private val m2 = Movement("2", "test2", Some("consigneeId2"), Some("arc2"), Instant.now)
+  private val m3 = Movement("5", "test2", Some("consigneeId2"), Some("arc3"), Instant.now)
+  private val m4 = Movement("2", "test4", Some("consigneeId2"), Some("arc4"), Instant.now)
+  private val m5 = Movement("lrn345", "test2abc", Some("consigneeId2"), Some("arc3fgn"), Instant.now)
 
   private val movements = Seq(m1, m2, m3, m4, m5)
 
@@ -45,6 +47,12 @@ class MovementFilterSpec extends PlaySpec {
 
     "filter by ARC" in {
       val filter = MovementFilter.and(Seq("arc" -> Some("arc1")))
+
+      filter.filterMovement(movements) mustBe Seq(m1)
+    }
+
+    "filter by lastUpdated" in {
+      val filter = MovementFilter.and(Seq("lastUpdated" -> Some(Instant.now.toString())))
 
       filter.filterMovement(movements) mustBe Seq(m1)
     }

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/service/MovementServiceSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/service/MovementServiceSpec.scala
@@ -25,7 +25,7 @@ import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.Json
 import play.api.mvc.Results.{BadRequest, InternalServerError}
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
-import uk.gov.hmrc.excisemovementcontrolsystemapi.filters.MovementFilter
+import uk.gov.hmrc.excisemovementcontrolsystemapi.filters.MovementFilterBuilder
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.messages.IEMessage
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.{ErrorResponse, MessageTypes}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.MovementRepository
@@ -245,7 +245,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.getMovementByERN(Seq(consignorId)))
         .thenReturn(Future.successful(Seq(expectedMovement1, expectedMovement2)))
 
-      val filter = MovementFilter.and(Seq("ern" -> Some(consignorId)))
+      val filter = MovementFilterBuilder().withErn(Some(consignorId)).withLrn(None).withArc(None).withUpdatedSince(None).build()
       val result = await(movementService.getMovementByErn(Seq(consignorId), filter))
 
       result mustBe Seq(expectedMovement1)
@@ -259,7 +259,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.getMovementByERN(Seq(consignorId)))
         .thenReturn(Future.successful(Seq(expectedMovement1, expectedMovement2)))
 
-      val filter = MovementFilter.and(Seq("lrn" -> Some(lrnToFilterBy)))
+      val filter = MovementFilterBuilder().withErn(None).withLrn(Some(lrnToFilterBy)).withArc(None).withUpdatedSince(None).build()
       val result = await(movementService.getMovementByErn(Seq(consignorId), filter))
 
       result mustBe Seq(expectedMovement2)
@@ -273,7 +273,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.getMovementByERN(Seq(consignorId)))
         .thenReturn(Future.successful(Seq(expectedMovement1, expectedMovement2)))
 
-      val filter = MovementFilter.and(Seq("arc" -> Some(arcToFilterBy)))
+      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(Some(arcToFilterBy)).withUpdatedSince(None).build()
       val result = await(movementService.getMovementByErn(Seq(consignorId), filter))
 
       result mustBe Seq(expectedMovement2)
@@ -288,7 +288,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.getMovementByERN(Seq(consignorId)))
         .thenReturn(Future.successful(Seq(expectedMovement1, expectedMovement2, expectedMovement3, expectedMovement4)))
 
-      val filter = MovementFilter.and(Seq("ern" -> Some(ernToFilterBy), "lrn" -> Some(lrnToFilterBy)))
+      val filter = MovementFilterBuilder().withErn(Some(ernToFilterBy)).withLrn(Some(lrnToFilterBy)).withArc(None).withUpdatedSince(None).build()
       val result = await(movementService.getMovementByErn(Seq(consignorId), filter))
 
       result mustBe Seq(expectedMovement4)
@@ -305,11 +305,11 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.getMovementByERN(Seq(consignorId)))
         .thenReturn(Future.successful(Seq(expectedMovement1, expectedMovement2, expectedMovement3, expectedMovement4, expectedMovement5)))
 
-      val filter = MovementFilter.and(Seq(
-        "ern" -> Some(ernToFilterBy),
-        "lrn" -> Some(lrnToFilterBy),
-        "arc" -> Some(arcToFilterBy)
-      ))
+      val filter = MovementFilterBuilder()
+        .withErn(Some(ernToFilterBy))
+        .withLrn(Some(lrnToFilterBy))
+        .withArc(Some(arcToFilterBy))
+        .withUpdatedSince(None).build()
       val result = await(movementService.getMovementByErn(Seq(consignorId), filter))
 
       result mustBe Seq(expectedMovement4)

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/service/MovementServiceSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/service/MovementServiceSpec.scala
@@ -140,8 +140,8 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
 
   "getMovementByLRNAndERNIn with valid LRN and ERN combination" should {
     "return  a movement" in {
-      val message1 = Message("123456", "IE801", dateTimeService)
-      val message2 = Message("ABCDE", "IE815", dateTimeService)
+      val message1 = Message("123456", "IE801", dateTimeService.timestamp())
+      val message2 = Message("ABCDE", "IE815", dateTimeService.timestamp())
       val movement = Movement(lrn, consignorId, Some(consigneeId), None, Instant.now(), Seq(message1, message2))
       when(mockMovementRepository.getMovementByLRNAndERNIn(any, any))
         .thenReturn(Future.successful(Seq(movement)))
@@ -327,8 +327,8 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
 
   "updateMovement" should {
 
-    val cachedMessage1 = Message("<IE801>test</IE801>", MessageTypes.IE801.value, dateTimeService)
-    val cachedMessage2 = Message("<IE802>test</IE802>", MessageTypes.IE802.value, dateTimeService)
+    val cachedMessage1 = Message("<IE801>test</IE801>", MessageTypes.IE801.value, dateTimeService.timestamp())
+    val cachedMessage2 = Message("<IE802>test</IE802>", MessageTypes.IE802.value, dateTimeService.timestamp())
 
     //For these tests use a real EmcsUtils as we don't need the dateTime stubbed
     val movementServiceForUpdateTests = new MovementService(mockMovementRepository, new EmcsUtils, dateTimeService)
@@ -338,7 +338,8 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       Movement("345", consignorId, None, Some("89"), now, Seq.empty),
       Movement("345", "12", None, Some("890"), now, Seq.empty)
     )
-    val expectedMessage = createMessage("<IE818>test</IE818>", MessageTypes.IE818.value)
+    val encodeMessage = Base64.getEncoder.encodeToString("<IE818>test</IE818>".getBytes(StandardCharsets.UTF_8))
+    val expectedMessage = Message(encodeMessage, MessageTypes.IE818.value, dateTimeService.timestamp())
 
     "save movement" when {
       "message contains Administration Reference Code (ARC)" in {
@@ -379,7 +380,9 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
         eqTo(Movement("123", consignorId, None, Some("456"), now, Seq(expectedMessage))))
     }
 
+
     "throw an error" when {
+
       "message has both ARC and LRN missing" in {
         setUpForUpdateMovement(newMessage, None, None, "<foo>test</foo>", cachedMovements)
 
@@ -454,6 +457,6 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
 
   private def createMessage(xml: String, messageType: String) = {
     val encodeMessage = Base64.getEncoder.encodeToString(xml.getBytes(StandardCharsets.UTF_8))
-    Message(encodeMessage, messageType, dateTimeService)
+    Message(encodeMessage, messageType, dateTimeService.timestamp())
   }
 }

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/service/MovementServiceSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/service/MovementServiceSpec.scala
@@ -245,7 +245,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.getMovementByERN(Seq(consignorId)))
         .thenReturn(Future.successful(Seq(expectedMovement1, expectedMovement2)))
 
-      val filter = MovementFilterBuilder().withErn(Some(consignorId)).withLrn(None).withArc(None).withUpdatedSince(None).build()
+      val filter = MovementFilterBuilder().withErn(Some(consignorId)).build()
       val result = await(movementService.getMovementByErn(Seq(consignorId), filter))
 
       result mustBe Seq(expectedMovement1)
@@ -259,7 +259,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.getMovementByERN(Seq(consignorId)))
         .thenReturn(Future.successful(Seq(expectedMovement1, expectedMovement2)))
 
-      val filter = MovementFilterBuilder().withErn(None).withLrn(Some(lrnToFilterBy)).withArc(None).withUpdatedSince(None).build()
+      val filter = MovementFilterBuilder().withLrn(Some(lrnToFilterBy)).build()
       val result = await(movementService.getMovementByErn(Seq(consignorId), filter))
 
       result mustBe Seq(expectedMovement2)
@@ -273,7 +273,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.getMovementByERN(Seq(consignorId)))
         .thenReturn(Future.successful(Seq(expectedMovement1, expectedMovement2)))
 
-      val filter = MovementFilterBuilder().withErn(None).withLrn(None).withArc(Some(arcToFilterBy)).withUpdatedSince(None).build()
+      val filter = MovementFilterBuilder().withArc(Some(arcToFilterBy)).build()
       val result = await(movementService.getMovementByErn(Seq(consignorId), filter))
 
       result mustBe Seq(expectedMovement2)
@@ -288,7 +288,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.getMovementByERN(Seq(consignorId)))
         .thenReturn(Future.successful(Seq(expectedMovement1, expectedMovement2, expectedMovement3, expectedMovement4)))
 
-      val filter = MovementFilterBuilder().withErn(Some(ernToFilterBy)).withLrn(Some(lrnToFilterBy)).withArc(None).withUpdatedSince(None).build()
+      val filter = MovementFilterBuilder().withErn(Some(ernToFilterBy)).withLrn(Some(lrnToFilterBy)).build()
       val result = await(movementService.getMovementByErn(Seq(consignorId), filter))
 
       result mustBe Seq(expectedMovement4)
@@ -309,7 +309,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
         .withErn(Some(ernToFilterBy))
         .withLrn(Some(lrnToFilterBy))
         .withArc(Some(arcToFilterBy))
-        .withUpdatedSince(None).build()
+        .build()
       val result = await(movementService.getMovementByErn(Seq(consignorId), filter))
 
       result mustBe Seq(expectedMovement4)


### PR DESCRIPTION
Adds the query parameters to the get messages and get movements endpoints, to filter by date and time.
Inputting the incorrect format of date will return a BAD REQUEST response to the user.