### PR TITLE
Consignee filtering on GetMovements

### DIFF
--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilter.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilter.scala
@@ -27,7 +27,7 @@ sealed trait Filter {
 case class FilterErn(ern: Option[String] = None) extends Filter {
   def filter(movements: Seq[Movement]): Seq[Movement] = {
     ern.fold[Seq[Movement]](movements)(e =>
-      movements.filter(o => o.consignorId.equals(e))
+      movements.filter(o => o.consignorId.equals(e) || o.consigneeId.contains(e))
     )
   }
 }
@@ -70,7 +70,7 @@ case class MovementFilter (private val filter: Seq[Filter]) {
 }
 
 object MovementFilter {
-  def empty = MovementFilter(Seq.empty)
+  def empty: MovementFilter = MovementFilter(Seq.empty)
 }
 
 case class MovementFilterBuilder(private val filters: Seq[Filter]) {

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementService.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementService.scala
@@ -108,7 +108,7 @@ class MovementService @Inject()(
         updateMovementForIndividualArc(message, ern, cachedMovements, messageArc)
       }
 
-      Future.sequence(results).map{ boolSeq => boolSeq.forall(identity)}
+      Future.sequence(results).map { boolSeq => boolSeq.forall(identity) }
     }).flatten
   }
 
@@ -149,6 +149,8 @@ class MovementService @Inject()(
   }
 
   private def isLrnAlreadyUsed(movement: Movement, movementFromDb: Movement) = {
-    movementFromDb.administrativeReferenceCode.isDefined || movementFromDb.consigneeId != movement.consigneeId
+    movement.consignorId == movementFromDb.consignorId &&
+      (movementFromDb.administrativeReferenceCode.isDefined
+        || movementFromDb.consigneeId != movement.consigneeId)
   }
 }

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMessagesControllerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMessagesControllerSpec.scala
@@ -36,8 +36,7 @@ import uk.gov.hmrc.excisemovementcontrolsystemapi.services.{MovementService, Wor
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.EmcsUtils
 import uk.gov.hmrc.mongo.TimestampSupport
 
-import java.time.{Instant, LocalDate, LocalDateTime, LocalTime}
-import java.time.format.DateTimeParseException
+import java.time.{Instant, LocalDateTime}
 import scala.concurrent.{ExecutionContext, Future}
 
 class GetMessagesControllerSpec extends PlaySpec
@@ -54,7 +53,7 @@ class GetMessagesControllerSpec extends PlaySpec
   private val cc = stubControllerComponents()
   private val lrn = "LRN1234"
   private val dateTimeService = mock[TimestampSupport]
-  private val timeStamp = LocalDateTime.of(2020,1,1,1,1,1,1)
+  private val timeStamp = LocalDateTime.of(2020, 1, 1, 1, 1, 1, 1)
   private val workItemService = mock[WorkItemService]
   private val emcsUtils = mock[EmcsUtils]
 
@@ -125,7 +124,7 @@ class GetMessagesControllerSpec extends PlaySpec
       val message = Message("message", "IE801", timeInFuture)
       val message2 = Message("message2", "IE801", timeInPast)
       val message3 = Message("message3", "IE801", timeNow)
-      val movement = Movement("lrn", "consignorId", Some("consigneeId"), Some("arc"), Instant.now, Seq(message,message2, message3))
+      val movement = Movement("lrn", "consignorId", Some("consigneeId"), Some("arc"), Instant.now, Seq(message, message2, message3))
       when(movementService.getMovementByLRNAndERNIn(any, any))
         .thenReturn(Future.successful(Some(movement)))
 

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsControllerSpec.scala
@@ -26,7 +26,7 @@ import play.api.http.Status.{BAD_REQUEST, OK}
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{await, contentAsJson, defaultAwaitTimeout, status, stubControllerComponents}
-import uk.gov.hmrc.excisemovementcontrolsystemapi.filters.{MovementFilter, MovementFilterBuilder}
+import uk.gov.hmrc.excisemovementcontrolsystemapi.filters.MovementFilterBuilder
 import uk.gov.hmrc.excisemovementcontrolsystemapi.fixture.{FakeAuthentication, MovementTestUtils}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.ErrorResponse
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
@@ -48,7 +48,7 @@ class GetMovementsControllerSpec
   private val workItemService = mock[WorkItemService]
   private val emcsUtils = mock[EmcsUtils]
   private val controller = new GetMovementsController(FakeSuccessAuthentication, cc, movementService, workItemService, emcsUtils)
-  private val timeStamp = LocalDateTime.of(2020,1,1,1,1,1,1)
+  private val timeStamp = LocalDateTime.of(2020, 1, 1, 1, 1, 1, 1)
 
   override def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilterSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/filters/MovementFilterSpec.scala
@@ -23,7 +23,7 @@ import java.time.Instant
 
 class MovementFilterSpec extends PlaySpec {
 
-  val now = Instant.now()
+  private val now = Instant.now()
 
   private val m1 = Movement("lrn3", "test1", Some("consigneeId"), Some("arc1"), now.plusSeconds(500))
   private val m2 = Movement("2", "test2", Some("consigneeId2"), Some("arc2"), now.plusSeconds(1000))
@@ -45,6 +45,12 @@ class MovementFilterSpec extends PlaySpec {
       val filter = MovementFilterBuilder().withErn(Some("test1")).build()
 
       filter.filterMovement(movements) mustBe Seq(m1)
+    }
+
+    "filter by ERN should find consignee" in {
+      val filter = MovementFilterBuilder().withErn(Some("consigneeId2")).build()
+
+      filter.filterMovement(movements) mustBe Seq(m2, m3, m4, m5)
     }
 
     "filter by ARC" in {

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/fixture/MovementTestUtils.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/fixture/MovementTestUtils.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.excisemovementcontrolsystemapi.fixture
 
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.GetMovementResponse
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 
 trait MovementTestUtils {
 
@@ -31,6 +32,18 @@ trait MovementTestUtils {
       lrn,
       consigneeId,
       Some(arc),
+      "Accepted"
+    )
+  }
+
+  def createMovementResponseFromMovement(
+                             movement: Movement
+                            ): GetMovementResponse = {
+    GetMovementResponse(
+      movement.consignorId,
+      movement.localReferenceNumber,
+      movement.consigneeId,
+      movement.administrativeReferenceCode,
       "Accepted"
     )
   }


### PR DESCRIPTION
Also ensuring LRN uniqueness is only forced on the consignor, e.g. if you have LRN1 as a consignee, you could create LRN1 as a consignor.