### PR TITLE
reducing polling time for local testing

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -86,12 +86,12 @@ scheduler {
     }
 
     workItems {
-        inProgressTimeOut = 1 minutes
+        inProgressTimeOut = 1 second
         failureRetryAttempts = 3
-        failureRetryAfter = 5 minutes
+        failureRetryAfter = 5 seconds
         fastIntervalRetryAttempts = 3
-        fastInterval = 5 minutes
-        slowInterval = 1 hour
+        fastInterval = 5 seconds
+        slowInterval = 60 seconds
     }
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -86,7 +86,7 @@ scheduler {
     }
 
     workItems {
-        inProgressTimeOut = 1 second
+        inProgressTimeOut = 1 minutes
         failureRetryAttempts = 3
         failureRetryAfter = 5 seconds
         fastIntervalRetryAttempts = 3


### PR DESCRIPTION
This is overridden in environments above local, by config in app-config-base, which sets the polling time to 5 mins and 1hr.