### PR TITLE
Implement push notification worker

### DIFF
--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/DraftExciseMovementController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/DraftExciseMovementController.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.excisemovementcontrolsystemapi.models.messages.{IE815Message,
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.notification.Constants
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.validation._
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.{ErrorResponse, ExciseMovementResponse}
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.BoxIdRepository
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 import uk.gov.hmrc.excisemovementcontrolsystemapi.services._
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.DateTimeService
@@ -48,6 +49,7 @@ class DraftExciseMovementController @Inject()(
   messageValidator: MessageValidation,
   dateTimeService: DateTimeService,
   auditService: AuditService,
+  boxIdRepository: BoxIdRepository,
   appConfig: AppConfig,
   cc: ControllerComponents
 )(implicit ec: ExecutionContext)
@@ -109,6 +111,7 @@ class DraftExciseMovementController @Inject()(
   )(implicit hc: HeaderCarrier): EitherT[Future, Result, Movement] = {
 
     val newMovement: Movement = createMovementFomMessage(message, boxId)
+    boxId.map(boxIdRepository.save(newMovement.consignorId, _))
     workItemService.addWorkItemForErn(newMovement.consignorId, fastMode = true)
 
     EitherT(movementMessageService.saveNewMovement(newMovement).map {

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/BoxIdRepository.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/BoxIdRepository.scala
@@ -45,8 +45,8 @@ class BoxIdRepository @Inject()
   replaceIndexes = true
 ) with Logging {
 
-  def getBoxIds(ern: String): Future[Seq[String]] = Mdc.preservingMdc {
-    collection.find(Filters.eq("ern", ern)).map(_.boxId).toFuture()
+  def getBoxIds(ern: String): Future[Set[String]] = Mdc.preservingMdc {
+    collection.find(Filters.eq("ern", ern)).map(_.boxId).toFuture().map(_.toSet)
   }
 
   def save(ern: String, boxId: String): Future[Done] = Mdc.preservingMdc {

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/BoxIdRepository.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/BoxIdRepository.scala
@@ -16,11 +16,9 @@
 
 package uk.gov.hmrc.excisemovementcontrolsystemapi.repository
 
-import cats.implicits.toFunctorOps
 import org.apache.pekko.Done
 import org.mongodb.scala.model.{Filters, IndexModel, IndexOptions, Indexes, ReplaceOptions}
 import play.api.{Configuration, Logging}
-import uk.gov.hmrc.excisemovementcontrolsystemapi.config.AppConfig
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.BoxIdRecord
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.BoxIdRepository.mongoIndexes
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.DateTimeService

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/ErnRetrievalRepository.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/ErnRetrievalRepository.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.excisemovementcontrolsystemapi.repository
 
-import org.apache.pekko.Done
 import org.mongodb.scala.model._
 import play.api.Logging
 import uk.gov.hmrc.excisemovementcontrolsystemapi.config.AppConfig
@@ -52,14 +51,6 @@ class ErnRetrievalRepository @Inject()
       ErnRetrieval(ern, timeService.timestamp()),
       FindOneAndReplaceOptions().upsert(true)
     ).headOption().map(_.map(_.lastRetrieved))
-  }
-
-  def save(ern: String): Future[Done] = Mdc.preservingMdc {
-    collection.replaceOne(
-      Filters.eq("ern", ern),
-      ErnRetrieval(ern, timeService.timestamp()),
-      ReplaceOptions().upsert(true)
-    ).toFuture().map(_ => Done)
   }
 }
 

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
@@ -24,7 +24,7 @@ import org.mongodb.scala.model._
 import play.api.Logging
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.config.AppConfig
-import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.MovementMessageRepository.{ErnAndLastReceived, MessageNotification, mongoIndexes}
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.MovementRepository.{ErnAndLastReceived, MessageNotification, mongoIndexes}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.DateTimeService
 import uk.gov.hmrc.mongo.MongoComponent
@@ -53,8 +53,8 @@ class MovementRepository @Inject()
     domainFormat = Movement.format,
     indexes = mongoIndexes(appConfig.movementTTL),
     extraCodecs = Seq(
-      Codecs.playFormatCodec(MovementMessageRepository.ErnAndLastReceived.format),
-      Codecs.playFormatCodec(MovementMessageRepository.MessageNotification.format)
+      Codecs.playFormatCodec(ErnAndLastReceived.format),
+      Codecs.playFormatCodec(MessageNotification.format)
     ),
     replaceIndexes = true
   ) with Logging {
@@ -160,7 +160,7 @@ class MovementRepository @Inject()
   }
 }
 
-object MovementMessageRepository {
+object MovementRepository {
   def mongoIndexes(ttl: Duration): Seq[IndexModel] =
     Seq(
       IndexModel(

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
@@ -129,7 +129,7 @@ class MovementRepository @Inject()
     }
   }
 
-  def getPendingMessageNotifications(): Future[Seq[MessageNotification]] = Mdc.preservingMdc {
+  def getPendingMessageNotifications: Future[Seq[MessageNotification]] = Mdc.preservingMdc {
     collection.aggregate[MessageNotification](Seq(
       // This match is to do an initial filter which filters out all movements that have no
       // messages which need to notify.

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/PushNotificationJob.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/PushNotificationJob.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.excisemovementcontrolsystemapi.scheduling
+
+import cats.syntax.all._
+import org.apache.pekko.Done
+import play.api.{Configuration, Logging}
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.MovementRepository
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.MovementRepository.MessageNotification
+import uk.gov.hmrc.excisemovementcontrolsystemapi.services.PushNotificationService
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NonFatal
+
+@Singleton
+class PushNotificationJob @Inject
+(
+  configuration: Configuration,
+  movementRepository: MovementRepository,
+  pushNotificationService: PushNotificationService
+) extends ScheduledJob with Logging {
+
+  override def name: String = "push-notification-job"
+
+  override def execute(implicit ec: ExecutionContext): Future[Done] = {
+    movementRepository.getPendingMessageNotifications.flatMap { notifications =>
+      notifications.traverse { notification =>
+        processNotification(notification).recover { case NonFatal(_) =>
+          logger.info(s"Failed to notify ${notification.recipient} for message ${notification.messageId}. Will try again later.")
+          Done
+        }
+      }
+    }.as(Done)
+  }
+
+  private def processNotification(notification: MessageNotification)(implicit ec: ExecutionContext): Future[Done] = {
+    for {
+      _ <- sendNotification(notification)
+      _ <- confirmNotification(notification)
+    } yield Done
+  }
+
+  private def sendNotification(notification: MessageNotification): Future[Done] = {
+    pushNotificationService.sendNotification(
+      notification.boxId,
+      notification.recipient,
+      notification.movementId,
+      notification.messageId,
+      notification.messageType,
+      notification.consignor,
+      notification.consignee,
+      notification.arc
+    )
+  }
+
+  private def confirmNotification(notification: MessageNotification): Future[Done] = {
+    movementRepository.confirmNotification(notification.movementId, notification.messageId, notification.boxId)
+  }
+
+  override val enabled: Boolean = true
+  override def initialDelay: FiniteDuration = configuration.get[FiniteDuration]("scheduler.pushNotificationJob.initialDelay")
+  override def interval: FiniteDuration = configuration.get[FiniteDuration]("scheduler.pushNotificationJob.interval")
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+}

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageService.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageService.scala
@@ -53,7 +53,6 @@ class MessageService @Inject
         for {
           boxIds <- getBoxIds(ern)
           _ <- processNewMessages(ern, boxIds)
-          _ <- ernRetrievalRepository.save(ern)
         } yield Done
       } else {
         Future.successful(Done)

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageService.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageService.scala
@@ -22,7 +22,7 @@ import play.api.{Configuration, Logging}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.MessageConnector
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.messages._
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.{Message, Movement}
-import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.{ErnRetrievalRepository, MovementRepository}
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.{BoxIdRepository, ErnRetrievalRepository, MovementRepository}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.{DateTimeService, EmcsUtils}
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -37,6 +37,7 @@ class MessageService @Inject
   configuration: Configuration,
   movementRepository: MovementRepository,
   ernRetrievalRepository: ErnRetrievalRepository,
+  boxIdRepository: BoxIdRepository,
   messageConnector: MessageConnector,
   dateTimeService: DateTimeService,
   correlationIdService: CorrelationIdService,
@@ -50,7 +51,8 @@ class MessageService @Inject
     ernRetrievalRepository.getLastRetrieved(ern).flatMap { maybeLastRetrieved =>
       if (shouldProcessNewMessages(maybeLastRetrieved)) {
         for {
-          _ <- processNewMessages(ern)
+          boxIds <- getBoxIds(ern)
+          _ <- processNewMessages(ern, boxIds)
           _ <- ernRetrievalRepository.save(ern)
         } yield Done
       } else {
@@ -65,31 +67,35 @@ class MessageService @Inject
     maybeLastRetrieved.map(_.isBefore(cutoffTime)).getOrElse(true)
   }
 
-  private def processNewMessages(ern: String)(implicit hc: HeaderCarrier): Future[Done] =
+  private def getBoxIds(ern: String): Future[Set[String]] = {
+    boxIdRepository.getBoxIds(ern)
+  }
+
+  private def processNewMessages(ern: String, boxIds: Set[String])(implicit hc: HeaderCarrier): Future[Done] =
     for {
       response <- messageConnector.getNewMessages(ern)
-      _ <- updateMovements(ern, response.messages)
-      _ <- acknowledgeAndContinue(response, ern)
+      _ <- updateMovements(ern, response.messages, boxIds)
+      _ <- acknowledgeAndContinue(response, ern, boxIds)
     } yield Done
 
-  private def acknowledgeAndContinue(response: GetMessagesResponse, ern: String)(implicit hc: HeaderCarrier): Future[Done] =
+  private def acknowledgeAndContinue(response: GetMessagesResponse, ern: String, boxIds: Set[String])(implicit hc: HeaderCarrier): Future[Done] =
     if (response.messageCount == 0) {
       Future.successful(Done)
     } else {
       messageConnector.acknowledgeMessages(ern).flatMap { _ =>
         if (response.messageCount > response.messages.size) {
-          processNewMessages(ern)
+          processNewMessages(ern, boxIds)
         } else {
           Future.successful(Done)
         }
       }
     }
 
-  private def updateMovements(ern: String, messages: Seq[IEMessage])(implicit hc: HeaderCarrier): Future[Done] = {
+  private def updateMovements(ern: String, messages: Seq[IEMessage], boxIds: Set[String])(implicit hc: HeaderCarrier): Future[Done] = {
     if (messages.nonEmpty) {
       movementRepository.getAllBy(ern).flatMap { movements =>
         messages.foldLeft(Seq.empty[Movement]) { (updatedMovements, message) =>
-          updateOrCreateMovements(ern, movements, updatedMovements, message)
+          updateOrCreateMovements(ern, movements, updatedMovements, message, boxIds)
         }.traverse(movementRepository.save)
       }.as(Done)
     } else {
@@ -97,27 +103,33 @@ class MessageService @Inject
     }
   }
 
-  private def updateOrCreateMovements(ern: String, movements: Seq[Movement], updatedMovements: Seq[Movement], message: IEMessage)(implicit hc: HeaderCarrier): Seq[Movement] = {
+  private def updateOrCreateMovements(
+    ern: String,
+    movements: Seq[Movement],
+    updatedMovements: Seq[Movement],
+    message: IEMessage,
+    boxIds: Set[String]
+  )(implicit hc: HeaderCarrier): Seq[Movement] = {
     val matchedMovements: Seq[Movement] = findMovementsForMessage(movements, updatedMovements, message)
 
     (
       if (matchedMovements.nonEmpty) matchedMovements.map { movement =>
-        Some(updateMovement(ern, movement, message))
+        Some(updateMovement(ern, movement, message, boxIds))
       } else {
-        createMovement(ern, message)
+        createMovement(ern, message, boxIds)
       } +: updatedMovements.map(Some(_))
     ).flatten.distinctBy(_._id)
   }
 
-  private def updateMovement(recipient: String, movement: Movement, message: IEMessage): Movement = {
-    movement.copy(messages = getUpdatedMessages(recipient, movement, message),
+  private def updateMovement(recipient: String, movement: Movement, message: IEMessage, boxIds: Set[String]): Movement = {
+    movement.copy(messages = getUpdatedMessages(recipient, movement, message, boxIds),
       administrativeReferenceCode = getArc(movement, message),
       consigneeId = getConsignee(movement, message)
     )
   }
 
-  private def getUpdatedMessages(recipient: String, movement: Movement, message: IEMessage): Seq[Message] = {
-    (movement.messages :+ convertMessage(recipient, message)).distinctBy(_.messageId)
+  private def getUpdatedMessages(recipient: String, movement: Movement, message: IEMessage, boxIds: Set[String]): Seq[Message] = {
+    (movement.messages :+ convertMessage(recipient, message, boxIds)).distinctBy(_.messageId)
   }
 
   private def findMovementsForMessage(movements: Seq[Movement], updatedMovements: Seq[Movement], message: IEMessage): Seq[Movement] = {
@@ -142,10 +154,10 @@ class MessageService @Inject
     }
   }
 
-  private def createMovement(ern: String, message: IEMessage)(implicit hc: HeaderCarrier): Option[Movement] = {
+  private def createMovement(ern: String, message: IEMessage, boxIds: Set[String])(implicit hc: HeaderCarrier): Option[Movement] = {
     message match {
-      case ie704: IE704Message => Some(createMovementFromIE704(ern, ie704))
-      case ie801: IE801Message => Some(createMovementFromIE801(ern, ie801))
+      case ie704: IE704Message => Some(createMovementFromIE704(ern, ie704, boxIds))
+      case ie801: IE801Message => Some(createMovementFromIE801(ern, ie801, boxIds))
       case ieMessage: IEMessage =>
         val errorMessage = s"An ${ieMessage.messageType} message has been retrieved with no movement, unable to create movement"
         auditService.auditMessage(ieMessage, errorMessage)
@@ -154,7 +166,7 @@ class MessageService @Inject
     }
   }
 
-  private def createMovementFromIE704(consignor: String, message: IE704Message): Movement = {
+  private def createMovementFromIE704(consignor: String, message: IE704Message, boxIds: Set[String]): Movement = {
     Movement(
       correlationIdService.generateCorrelationId(),
       None,
@@ -163,11 +175,11 @@ class MessageService @Inject
       None,
       administrativeReferenceCode = message.administrativeReferenceCode.head, // TODO remove .head
       dateTimeService.timestamp(),
-      messages = Seq(convertMessage(consignor, message))
+      messages = Seq(convertMessage(consignor, message, boxIds))
     )
   }
 
-  private def createMovementFromIE801(consignor: String, message: IE801Message): Movement = {
+  private def createMovementFromIE801(consignor: String, message: IE801Message, boxIds: Set[String]): Movement = {
     Movement(
       correlationIdService.generateCorrelationId(),
       None,
@@ -176,7 +188,7 @@ class MessageService @Inject
       message.consigneeId,
       administrativeReferenceCode = message.administrativeReferenceCode.head, // TODO remove .head
       dateTimeService.timestamp(),
-      messages = Seq(convertMessage(consignor, message))
+      messages = Seq(convertMessage(consignor, message, boxIds))
     )
   }
 
@@ -193,13 +205,13 @@ class MessageService @Inject
     movements.find(movement => message.lrnEquals(movement.localReferenceNumber))
       .map(Seq(_))
 
-  private def convertMessage(recipient: String, input: IEMessage): Message = {
+  private def convertMessage(recipient: String, input: IEMessage, boxIds: Set[String]): Message = {
     Message(
       encodedMessage = emcsUtils.encode(input.toXml.toString),
       messageType = input.messageType,
       messageId = input.messageIdentifier,
       recipient = recipient,
-      boxesToNotify = Set.empty, // TODO add boxes which should be notified about this message
+      boxesToNotify = boxIds,
       createdOn = dateTimeService.timestamp()
     )
   }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -93,12 +93,23 @@ mongodb {
 }
 
 scheduler {
+    # TODO Legacy polling job, remove
     pollingNewMessageJob {
+        initialDelay = 1 minutes
+        interval = 1 minutes
+    }
+
+    pollingNewMessagesJob {
         initialDelay = 1 minutes
         interval = 1 minutes
         fastPollingInterval = 5 seconds
         fastPollingCutoff = 10 seconds
         slowPollingInterval = 60 seconds
+    }
+
+    pushNotificationJob {
+        initialDelay = 1 minutes
+        interval = 1 minutes
     }
 
     workItems {

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/BoxIdRepositoryItSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/BoxIdRepositoryItSpec.scala
@@ -127,11 +127,11 @@ class BoxIdRepositoryItSpec extends PlaySpec
       insert(record1).futureValue
       insert(record2).futureValue
 
-      repository.getBoxIds("testErn").futureValue must contain theSameElementsAs Seq("testBoxId", "differentBoxId")
+      repository.getBoxIds("testErn").futureValue must contain theSameElementsAs Set("testBoxId", "differentBoxId")
     }
 
     "return and empty sequence if there are no records for the ERN" in {
-      repository.getBoxIds("testErn").futureValue mustBe Seq.empty
+      repository.getBoxIds("testErn").futureValue mustBe Set.empty
 
     }
     mustPreserveMdc(repository.getBoxIds("testErn"))

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/ErnRetrievalRepositoryItSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/ErnRetrievalRepositoryItSpec.scala
@@ -50,31 +50,6 @@ class ErnRetrievalRepositoryItSpec extends PlaySpec
 
   override protected lazy val repository: ErnRetrievalRepository = app.injector.instanceOf[ErnRetrievalRepository]
 
-  "save" should {
-    "save when there isn't one there already" in {
-      val fixedInstant = Instant.now.truncatedTo(ChronoUnit.MILLIS)
-      when(mockTimeService.timestamp()).thenReturn(fixedInstant)
-
-      repository.save("testErn").futureValue
-
-      find(Filters.eq("ern", "testErn")).futureValue.head mustBe ErnRetrieval("testErn", fixedInstant)
-    }
-
-    "update the lastRetrieved when there is one there already" in {
-      val originalInstant = Instant.now.truncatedTo(ChronoUnit.MILLIS).minusSeconds(60)
-      val updatedInstant = Instant.now.truncatedTo(ChronoUnit.MILLIS)
-      when(mockTimeService.timestamp()).thenReturn(updatedInstant)
-
-      insert(ErnRetrieval("testErn", originalInstant)).futureValue
-
-      repository.save("testErn").futureValue
-
-      find(Filters.eq("ern", "testErn")).futureValue.head mustBe ErnRetrieval("testErn", updatedInstant)
-    }
-
-    mustPreserveMdc(repository.save("testErn"))
-  }
-
   "getLastRetrieved" should {
 
     "return none and update the lastRetrieved time when ern does not exist" in {

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
@@ -417,12 +417,12 @@ class MovementRepositoryItSpec extends PlaySpec
         MessageNotification(movementId = movement2._id, messageId = "messageId3", messageType = "type", consignor = "consignorId", consignee = None, arc = Some("arc"), recipient = "recipient3", boxId = "boxId2")
       )
 
-      val result = repository.getPendingMessageNotifications().futureValue
+      val result = repository.getPendingMessageNotifications.futureValue
 
       result must contain theSameElementsAs expected
     }
 
-    mustPreserveMdc(repository.getPendingMessageNotifications())
+    mustPreserveMdc(repository.getPendingMessageNotifications)
   }
 
   "confirmNotification" should {

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
@@ -30,7 +30,7 @@ import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.excisemovementcontrolsystemapi.config.AppConfig
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.MessageTypes
-import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.MovementMessageRepository.MessageNotification
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.MovementRepository.MessageNotification
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.{Message, Movement}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.DateTimeService
 import uk.gov.hmrc.mongo.test.{CleanMongoCollectionSupport, DefaultPlayMongoRepositorySupport}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.20.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.21.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.5.0")
 addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.1")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.0.9")

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/PushNotificationJobSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/PushNotificationJobSpec.scala
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.excisemovementcontrolsystemapi.scheduling
+
+import org.apache.pekko.Done
+import org.mockito.ArgumentMatchersSugar.{any, eqTo}
+import org.mockito.Mockito
+import org.mockito.Mockito.never
+import org.mockito.MockitoSugar.{verify, when}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatestplus.mockito.MockitoSugar.mock
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.MovementRepository
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.MovementRepository.MessageNotification
+import uk.gov.hmrc.excisemovementcontrolsystemapi.services.PushNotificationService
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+class PushNotificationJobSpec extends PlaySpec
+  with ScalaFutures
+  with IntegrationPatience
+  with GuiceOneAppPerSuite
+  with BeforeAndAfterEach {
+
+  private val movementRepository = mock[MovementRepository]
+  private val pushNotificationService = mock[PushNotificationService]
+  private lazy val pushNotificationJob = app.injector.instanceOf[PushNotificationJob]
+
+  override def fakeApplication(): Application = GuiceApplicationBuilder()
+    .overrides(
+      bind[MovementRepository].toInstance(movementRepository),
+      bind[PushNotificationService].toInstance(pushNotificationService),
+    )
+    .configure(
+      "scheduler.pushNotificationJob.initialDelay" -> "2 minutes",
+      "scheduler.pushNotificationJob.interval" -> "1 minute",
+    ).build()
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    Mockito.reset[Any](
+      movementRepository,
+      pushNotificationService
+    )
+  }
+
+  "push notifications job" when {
+    "initialised" should {
+      "have the correct name" in {
+        pushNotificationJob.name mustBe "push-notification-job"
+      }
+      "be enabled" in {
+        pushNotificationJob.enabled mustBe true
+      }
+      "use initial delay from configuration" in {
+        pushNotificationJob.initialDelay mustBe FiniteDuration(2, "minutes")
+      }
+      "use interval from configuration" in {
+        pushNotificationJob.interval mustBe FiniteDuration(1, "minute")
+      }
+    }
+  }
+
+  "executing" when {
+    "there are no messages pending to be notified" should {
+      "not send any notifications" in {
+        when(movementRepository.getPendingMessageNotifications).thenReturn(Future.successful(Seq.empty))
+
+        pushNotificationJob.execute.futureValue
+
+        verify(pushNotificationService, never()).sendNotification(any, any, any, any, any, any, any, any)(any)
+      }
+    }
+    "there are messages pending to be notified" when {
+      "notifications are successfully sent for each message" should {
+        "send a notification for each message" in {
+          val notification1 = MessageNotification(
+            "movement1",
+            "message1",
+            "IE801",
+            "consignor",
+            Some("consignee"),
+            Some("arc1"),
+            "consignor",
+            "box1"
+          )
+          val notification2 = MessageNotification(
+            "movement1",
+            "message2",
+            "IE818",
+            "consignor",
+            Some("consignee"),
+            Some("arc2"),
+            "consignee",
+            "box2"
+          )
+          when(movementRepository.getPendingMessageNotifications).thenReturn(
+            Future.successful(Seq(notification1, notification2))
+          )
+          when(movementRepository.confirmNotification(any, any, any)).thenReturn(Future.successful(Done))
+          when(pushNotificationService.sendNotification(any, any, any, any, any, any, any, any)(any)).thenReturn(
+            Future.successful(Done)
+          )
+
+          pushNotificationJob.execute.futureValue
+
+          verify(pushNotificationService).sendNotification(
+            eqTo("box1"),
+            eqTo("consignor"),
+            eqTo("movement1"),
+            eqTo("message1"),
+            eqTo("IE801"),
+            eqTo("consignor"),
+            eqTo(Some("consignee")),
+            eqTo(Some("arc1")))(any)
+          verify(pushNotificationService).sendNotification(
+            eqTo("box2"),
+            eqTo("consignee"),
+            eqTo("movement1"),
+            eqTo("message2"),
+            eqTo("IE818"),
+            eqTo("consignor"),
+            eqTo(Some("consignee")),
+            eqTo(Some("arc2")))(any)
+        }
+        "confirm each notification" in {
+          val notification1 = MessageNotification(
+            "movement1",
+            "message1",
+            "IE801",
+            "consignor",
+            Some("consignee"),
+            Some("arc1"),
+            "consignor",
+            "box1"
+          )
+          val notification2 = MessageNotification(
+            "movement1",
+            "message2",
+            "IE818",
+            "consignor",
+            Some("consignee"),
+            Some("arc2"),
+            "consignee",
+            "box2"
+          )
+          when(movementRepository.getPendingMessageNotifications).thenReturn(
+            Future.successful(Seq(notification1, notification2))
+          )
+          when(movementRepository.confirmNotification(any, any, any)).thenReturn(Future.successful(Done))
+          when(pushNotificationService.sendNotification(any, any, any, any, any, any, any, any)(any)).thenReturn(
+            Future.successful(Done)
+          )
+
+          pushNotificationJob.execute.futureValue
+
+          verify(movementRepository).confirmNotification("movement1", "message1", "box1")
+          verify(movementRepository).confirmNotification("movement1", "message2", "box2")
+        }
+      }
+
+      "a notification fails for a message" should {
+        "not confirm a notification but process further notifications" in {
+          val notification1 = MessageNotification(
+            "movement1",
+            "message1",
+            "IE801",
+            "consignor",
+            Some("consignee"),
+            Some("arc1"),
+            "consignor",
+            "box1"
+          )
+          val notification2 = MessageNotification(
+            "movement1",
+            "message2",
+            "IE818",
+            "consignor",
+            Some("consignee"),
+            Some("arc2"),
+            "consignee",
+            "box2"
+          )
+          when(movementRepository.getPendingMessageNotifications).thenReturn(
+            Future.successful(Seq(notification1, notification2))
+          )
+          when(movementRepository.confirmNotification(any, any, any)).thenReturn(Future.successful(Done))
+          when(pushNotificationService.sendNotification(any, any, any, any, any, any, any, any)(any)).thenReturn(
+            Future.failed(new RuntimeException("Error")),
+            Future.successful(Done)
+          )
+
+          pushNotificationJob.execute.futureValue
+
+          verify(movementRepository, never()).confirmNotification("movement1", "message1", "box1")
+          verify(movementRepository).confirmNotification("movement1", "message2", "box2")
+        }
+      }
+
+      "a confirmation of a notification fails for a message" should {
+        "not fail the job and process further notifications" in {
+          val notification1 = MessageNotification(
+            "movement1",
+            "message1",
+            "IE801",
+            "consignor",
+            Some("consignee"),
+            Some("arc1"),
+            "consignor",
+            "box1"
+          )
+          val notification2 = MessageNotification(
+            "movement1",
+            "message2",
+            "IE818",
+            "consignor",
+            Some("consignee"),
+            Some("arc2"),
+            "consignee",
+            "box2"
+          )
+          when(movementRepository.getPendingMessageNotifications).thenReturn(
+            Future.successful(Seq(notification1, notification2))
+          )
+          when(movementRepository.confirmNotification(any, any, any)).thenReturn(
+            Future.failed(new RuntimeException("Error")),
+            Future.successful(Done)
+          )
+          when(pushNotificationService.sendNotification(any, any, any, any, any, any, any, any)(any)).thenReturn(
+            Future.successful(Done)
+          )
+
+          pushNotificationJob.execute.futureValue
+
+          verify(movementRepository).confirmNotification("movement1", "message2", "box2")
+        }
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageServiceSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageServiceSpec.scala
@@ -19,9 +19,7 @@ package uk.gov.hmrc.excisemovementcontrolsystemapi.services
 import cats.data.EitherT
 import org.apache.pekko.Done
 import org.mockito.ArgumentMatchersSugar.{any, eqTo}
-import org.mockito.Mockito
-import org.mockito.Mockito.never
-import org.mockito.MockitoSugar.{times, verify, when}
+import org.mockito.MockitoSugar.{never, reset, times, verify, when}
 import org.mockito.captor.ArgCaptor
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -83,7 +81,7 @@ class MessageServiceSpec extends PlaySpec
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    Mockito.reset[Any](
+    reset(
       movementRepository,
       ernRetrievalRepository,
       boxIdRepository,
@@ -112,9 +110,9 @@ class MessageServiceSpec extends PlaySpec
             messageService.updateMessages(ern).futureValue
 
             verify(messageConnector).getNewMessages(eqTo(ern))(any)
-            verify(movementRepository, never()).getAllBy(any)
-            verify(movementRepository, never()).save(any)
-            verify(messageConnector, never()).acknowledgeMessages(any)(any)
+            verify(movementRepository, never).getAllBy(any)
+            verify(movementRepository, never).save(any)
+            verify(messageConnector, never).acknowledgeMessages(any)(any)
           }
         }
         "we try to retrieve messages and there are some" should {

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageServiceSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageServiceSpec.scala
@@ -106,7 +106,6 @@ class MessageServiceSpec extends PlaySpec
             when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(movement)))
             when(movementRepository.save(any)).thenReturn(Future.successful(Done))
             when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-            when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
             when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
             when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(Seq.empty, 0)))
 
@@ -115,7 +114,6 @@ class MessageServiceSpec extends PlaySpec
             verify(messageConnector).getNewMessages(eqTo(ern))(any)
             verify(movementRepository, never()).getAllBy(any)
             verify(movementRepository, never()).save(any)
-            verify(ernRetrievalRepository).save(eqTo(ern))
             verify(messageConnector, never()).acknowledgeMessages(any)(any)
           }
         }
@@ -134,7 +132,6 @@ class MessageServiceSpec extends PlaySpec
             when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(lrnMovement, notLrnMovement)))
             when(movementRepository.save(any)).thenReturn(Future.successful(Done))
             when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-            when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
             when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
             when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 1)))
             when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -145,7 +142,6 @@ class MessageServiceSpec extends PlaySpec
             verify(movementRepository).getAllBy(ern)
             verify(movementRepository, never).save(unexpectedMovement)
             verify(movementRepository).save(expectedMovement)
-            verify(ernRetrievalRepository).save(ern)
             verify(messageConnector).acknowledgeMessages(eqTo(ern))(any)
           }
           "add messages to only the movement with the right ARC" in {
@@ -162,7 +158,6 @@ class MessageServiceSpec extends PlaySpec
             when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(arcMovement, notArcMovement)))
             when(movementRepository.save(any)).thenReturn(Future.successful(Done))
             when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-            when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
             when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
             when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 1)))
             when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -173,7 +168,6 @@ class MessageServiceSpec extends PlaySpec
             verify(movementRepository).getAllBy(ern)
             verify(movementRepository, never).save(unexpectedMovement)
             verify(movementRepository).save(expectedMovement)
-            verify(ernRetrievalRepository).save(ern)
             verify(messageConnector).acknowledgeMessages(eqTo(ern))(any)
           }
           "add the boxIds to notify to saved messages" in {
@@ -191,7 +185,6 @@ class MessageServiceSpec extends PlaySpec
             when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(arcMovement, notArcMovement)))
             when(movementRepository.save(any)).thenReturn(Future.successful(Done))
             when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-            when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
             when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(boxIds))
             when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 1)))
             when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -202,7 +195,6 @@ class MessageServiceSpec extends PlaySpec
             verify(movementRepository).getAllBy(ern)
             verify(movementRepository, never).save(unexpectedMovement)
             verify(movementRepository).save(expectedMovement)
-            verify(ernRetrievalRepository).save(ern)
             verify(boxIdRepository).getBoxIds(ern)
             verify(messageConnector).acknowledgeMessages(eqTo(ern))(any)
           }
@@ -223,7 +215,6 @@ class MessageServiceSpec extends PlaySpec
             when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(movement)))
             when(movementRepository.save(any)).thenReturn(Future.successful(Done))
             when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-            when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
             when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
             when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 1)))
             when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -233,7 +224,6 @@ class MessageServiceSpec extends PlaySpec
             verify(messageConnector).getNewMessages(eqTo(ern))(any)
             verify(movementRepository).getAllBy(eqTo(ern))
             verify(movementRepository).save(eqTo(expectedMovement))
-            verify(ernRetrievalRepository).save(eqTo(ern))
             verify(messageConnector).acknowledgeMessages(eqTo(ern))(any)
           }
         }
@@ -259,7 +249,6 @@ class MessageServiceSpec extends PlaySpec
           when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(movement1, movement2)))
           when(movementRepository.save(any)).thenReturn(Future.successful(Done))
           when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-          when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
           when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
           when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(Seq(message), 1)))
           when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -271,7 +260,6 @@ class MessageServiceSpec extends PlaySpec
           verify(messageConnector).getNewMessages(eqTo(ern))(any)
           verify(movementRepository).getAllBy(eqTo(ern))
           verify(movementRepository, times(2)).save(movementCaptor)
-          verify(ernRetrievalRepository).save(eqTo(ern))
           verify(messageConnector).acknowledgeMessages(eqTo(ern))(any)
 
           movementCaptor.values.head mustBe expectedMovement1
@@ -300,7 +288,6 @@ class MessageServiceSpec extends PlaySpec
             when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq.empty))
             when(movementRepository.save(any)).thenReturn(Future.successful(Done))
             when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-            when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
             when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
             when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 1)))
             when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -310,7 +297,6 @@ class MessageServiceSpec extends PlaySpec
             verify(messageConnector).getNewMessages(eqTo(ern))(any)
             verify(movementRepository).getAllBy(eqTo(ern))
             verify(movementRepository).save(eqTo(expectedMovement))
-            verify(ernRetrievalRepository).save(eqTo(ern))
             verify(messageConnector).acknowledgeMessages(eqTo(ern))(any)
           }
           "a new movement should be created from an IE801 message" in {
@@ -333,7 +319,6 @@ class MessageServiceSpec extends PlaySpec
             when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq.empty))
             when(movementRepository.save(any)).thenReturn(Future.successful(Done))
             when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-            when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
             when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
             when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 1)))
             when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -343,7 +328,6 @@ class MessageServiceSpec extends PlaySpec
             verify(messageConnector).getNewMessages(eqTo(ern))(any)
             verify(movementRepository).getAllBy(eqTo(ern))
             verify(movementRepository).save(eqTo(expectedMovement))
-            verify(ernRetrievalRepository).save(eqTo(ern))
             verify(messageConnector).acknowledgeMessages(eqTo(ern))(any)
           }
           "a message is audited with failure if its not an IE801 or IE704" in {
@@ -357,7 +341,6 @@ class MessageServiceSpec extends PlaySpec
             when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq.empty))
             when(movementRepository.save(any)).thenReturn(Future.successful(Done))
             when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-            when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
             when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
             when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 1)))
             when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -392,7 +375,6 @@ class MessageServiceSpec extends PlaySpec
             when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq.empty))
             when(movementRepository.save(any)).thenReturn(Future.successful(Done))
             when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-            when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
             when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
             when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 0)))
             when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -402,7 +384,6 @@ class MessageServiceSpec extends PlaySpec
             verify(messageConnector).getNewMessages(eqTo(ern))(any)
             verify(movementRepository).getAllBy(eqTo(ern))
             verify(movementRepository).save(eqTo(expectedMovement))
-            verify(ernRetrievalRepository).save(eqTo(ern))
           }
         }
       }
@@ -441,7 +422,6 @@ class MessageServiceSpec extends PlaySpec
           when(movementRepository.save(any)).thenReturn(Future.successful(Done))
 
           when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-          when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
           when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
           when(messageConnector.getNewMessages(any)(any)).thenReturn(
             Future.successful(GetMessagesResponse(Seq(firstMessage), 3)),
@@ -457,7 +437,6 @@ class MessageServiceSpec extends PlaySpec
           verify(messageConnector, times(3)).getNewMessages(eqTo(ern))(any)
           verify(movementRepository, times(3)).getAllBy(eqTo(ern))
           verify(movementRepository, times(3)).save(movementCaptor)
-          verify(ernRetrievalRepository).save(eqTo(ern))
           verify(messageConnector, times(3)).acknowledgeMessages(eqTo(ern))(any)
 
           movementCaptor.values.head mustEqual firstExpectedMovement
@@ -474,7 +453,6 @@ class MessageServiceSpec extends PlaySpec
         when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(movement)))
         when(movementRepository.save(any)).thenReturn(Future.successful(Done))
         when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(Some(now.minus(6, ChronoUnit.MINUTES))))
-        when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
         when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
         when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(Seq.empty, 0)))
 
@@ -492,7 +470,6 @@ class MessageServiceSpec extends PlaySpec
           when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(movement)))
           when(movementRepository.save(any)).thenReturn(Future.successful(Done))
           when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(Some(now.minus(5, ChronoUnit.MINUTES))))
-          when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
           when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
           when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(Seq.empty, 0)))
 
@@ -511,7 +488,6 @@ class MessageServiceSpec extends PlaySpec
           when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(movement)))
           when(movementRepository.save(any)).thenReturn(Future.successful(Done))
           when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(Some(now.minus(4, ChronoUnit.MINUTES))))
-          when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
           when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
           when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(Seq.empty, 0)))
 
@@ -536,7 +512,6 @@ class MessageServiceSpec extends PlaySpec
         when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(movement)))
         when(movementRepository.save(any)).thenReturn(Future.successful(Done))
         when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-        when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
         when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
         when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 1)))
         when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -558,7 +533,6 @@ class MessageServiceSpec extends PlaySpec
         when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(movement)))
         when(movementRepository.save(any)).thenReturn(Future.successful(Done))
         when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-        when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
         when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
         when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 1)))
         when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -582,7 +556,6 @@ class MessageServiceSpec extends PlaySpec
         when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(movement)))
         when(movementRepository.save(any)).thenReturn(Future.successful(Done))
         when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-        when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
         when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
         when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 1)))
         when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -604,7 +577,6 @@ class MessageServiceSpec extends PlaySpec
         when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(movement)))
         when(movementRepository.save(any)).thenReturn(Future.successful(Done))
         when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-        when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
         when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
         when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 1)))
         when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -628,7 +600,6 @@ class MessageServiceSpec extends PlaySpec
         when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(movement)))
         when(movementRepository.save(any)).thenReturn(Future.successful(Done))
         when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-        when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
         when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
         when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 1)))
         when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -653,7 +624,6 @@ class MessageServiceSpec extends PlaySpec
           when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(movement)))
           when(movementRepository.save(any)).thenReturn(Future.successful(Done))
           when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-          when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
           when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
           when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 1)))
           when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))
@@ -678,7 +648,6 @@ class MessageServiceSpec extends PlaySpec
           when(movementRepository.getAllBy(any)).thenReturn(Future.successful(Seq(movement)))
           when(movementRepository.save(any)).thenReturn(Future.successful(Done))
           when(ernRetrievalRepository.getLastRetrieved(any)).thenReturn(Future.successful(None))
-          when(ernRetrievalRepository.save(any)).thenReturn(Future.successful(Done))
           when(boxIdRepository.getBoxIds(any)).thenReturn(Future.successful(Set.empty))
           when(messageConnector.getNewMessages(any)(any)).thenReturn(Future.successful(GetMessagesResponse(messages, 1)))
           when(messageConnector.acknowledgeMessages(any)(any)).thenReturn(Future.successful(Done))


### PR DESCRIPTION
Implements the push notification worker

Adds the boxId to the BoxIdRepository on draft submission
Queries the boxIds in the updateMessages logic to add boxIds to be notified for saved messages
Removes save method from ErnRetrievalRepository as this has been replaced with a get and update in getLastRetrieved
Pulls any messages that are waiting to be notified
Notifies for each message waiting to be notified
Confirms notification for each message waiting to be notified