### PR TITLE
Handle IE704 received with no LRN

### DIFF
--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/models/messages/IE801Message.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/models/messages/IE801Message.scala
@@ -33,8 +33,8 @@ case class IE801Message(
   auditType: AuditType
 ) extends IEMessage
     with GeneratedJsonWriters {
-  def localReferenceNumber: Option[String] =
-    Some(obj.Body.EADESADContainer.EadEsad.LocalReferenceNumber)
+  def localReferenceNumber: String =
+    obj.Body.EADESADContainer.EadEsad.LocalReferenceNumber
 
   def consignorId: Option[String] =
     Some(obj.Body.EADESADContainer.ConsignorTrader.TraderExciseNumber)

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageService.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageService.scala
@@ -215,7 +215,7 @@ class MessageService @Inject() (
     Movement(
       correlationIdService.generateCorrelationId(),
       None,
-      message.localReferenceNumber.get, // TODO remove .get
+      message.localReferenceNumber,
       consignor,
       message.consigneeId,
       administrativeReferenceCode = message.administrativeReferenceCode.head, // TODO remove .head

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageService.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageService.scala
@@ -189,26 +189,37 @@ class MessageService @Inject() (
     hc: HeaderCarrier
   ): Option[Movement] =
     message match {
-      case ie704: IE704Message  => Some(createMovementFromIE704(ern, ie704, boxIds))
-      case ie801: IE801Message  => Some(createMovementFromIE801(ern, ie801, boxIds))
-      case ieMessage: IEMessage =>
-        val errorMessage =
-          s"An ${ieMessage.messageType} message has been retrieved with no movement, unable to create movement"
-        auditService.auditMessage(ieMessage, errorMessage)
-        logger.error(errorMessage)
-        None
+      case ie704: IE704Message => createMovementFromIE704(ern, ie704, boxIds)
+      case ie801: IE801Message => Some(createMovementFromIE801(ern, ie801, boxIds))
+      case _                   => auditMessageForNoMovement(message)
     }
 
-  private def createMovementFromIE704(consignor: String, message: IE704Message, boxIds: Set[String]): Movement =
-    Movement(
-      correlationIdService.generateCorrelationId(),
-      None,
-      message.localReferenceNumber.get, // TODO remove .get
-      consignor,
-      None,
-      administrativeReferenceCode = message.administrativeReferenceCode.head, // TODO remove .head
-      dateTimeService.timestamp(),
-      messages = Seq(convertMessage(consignor, message, boxIds))
+  private def auditMessageForNoMovement(message: IEMessage)(implicit
+    hc: HeaderCarrier
+  ): Option[Movement] = {
+    val errorMessage =
+      s"An ${message.messageType} message has been retrieved with no movement, unable to create movement"
+    auditService.auditMessage(message, errorMessage)
+    logger.error(errorMessage)
+    None
+  }
+
+  private def createMovementFromIE704(consignor: String, message: IE704Message, boxIds: Set[String])(implicit
+    hc: HeaderCarrier
+  ): Option[Movement] =
+    message.localReferenceNumber.fold[Option[Movement]](auditMessageForNoMovement(message))(lrn =>
+      Some(
+        Movement(
+          correlationIdService.generateCorrelationId(),
+          None,
+          lrn,
+          consignor,
+          None,
+          administrativeReferenceCode = message.administrativeReferenceCode.head, // TODO remove .head
+          dateTimeService.timestamp(),
+          messages = Seq(convertMessage(consignor, message, boxIds))
+        )
+      )
     )
 
   private def createMovementFromIE801(consignor: String, message: IE801Message, boxIds: Set[String]): Movement =

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -14,34 +14,12 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="ACCESS_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/access.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
-        </encoder>
-    </appender>
-
     <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/connector.log</file>
         <encoder>
             <pattern>%message%n</pattern>
         </encoder>
     </appender>
-
-
-    <logger name="accesslog" level="INFO" additivity="false">
-        <appender-ref ref="ACCESS_LOG_FILE" />
-    </logger>
-
-    <logger name="com.ning.http.client.providers.netty" additivity="false">
-        <appender-ref ref="STDOUT_IGNORE_NETTY" />
-    </logger>
 
     <logger name="com.google.inject" level="INFO"/>
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 )
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.21.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.22.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.5.0")
 addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.1")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.0.9")

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/factories/IEMessageFactorySpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/factories/IEMessageFactorySpec.scala
@@ -148,7 +148,7 @@ class IEMessageFactorySpec extends PlaySpec with TestXml with BeforeAndAfterEach
       result.consignorId mustBe Some("tokentokentok")
       result.consigneeId mustBe Some("token")
       result.administrativeReferenceCode mustBe Seq(Some("tokentokentokentokent"))
-      result.localReferenceNumber mustBe Some("token")
+      result.localReferenceNumber mustBe "token"
       result.messageIdentifier mustBe "token"
       result.messageType mustBe MessageTypes.IE801.value
       result.lrnEquals("token") mustBe true


### PR DESCRIPTION
We received the following XML message in the QA environment:

``` xml
<ns:IE704 xmlns:ns="http://www.govtalk.gov.uk/taxation/InternationalTrade/Excise/ie704uk/3">
        <ns:Header>
            <urn:MessageSender xmlns:urn="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:TMS:V3.13">NDEA.GB</urn:MessageSender>
            <urn:MessageRecipient xmlns:urn="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:TMS:V3.13">NDEA.GB</urn:MessageRecipient>
            <urn:DateOfPreparation xmlns:urn="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:TMS:V3.13">2018-02-09</urn:DateOfPreparation>
            <urn:TimeOfPreparation xmlns:urn="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:TMS:V3.13">10:42:18.545</urn:TimeOfPreparation>
            <urn:MessageIdentifier xmlns:urn="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:TMS:V3.13">GB100000000227379</urn:MessageIdentifier>
            <urn:CorrelationIdentifier xmlns:urn="urn:publicid:-:EC:DGTAXUD:EMCS:PHASE4:TMS:V3.13">PORTAL9ec0aa8cba7a4ab3b43b89a955d4a8ea</urn:CorrelationIdentifier>
        </ns:Header>
        <ns:Body>
            <ns:GenericRefusalMessage>
                <ns:Attributes>
                    <ns:AdministrativeReferenceCode>16GB00000000000192012</ns:AdministrativeReferenceCode>
                    <ns:SequenceNumber>2</ns:SequenceNumber>
                </ns:Attributes>
                <ns:FunctionalError>
                    <ns:ErrorType>4522</ns:ErrorType>
                    <ns:ErrorReason>Version of the Movement status invalid for Explanation for Shortage or Excess Message</ns:ErrorReason>
                    <ns:OriginalAttributeValue>none</ns:OriginalAttributeValue>
                </ns:FunctionalError>
            </ns:GenericRefusalMessage>
        </ns:Body>
    </ns:IE704>
```
    
This is an IE704 without an LRN in it and we don't have a movement for the ARC 16GB00000000000192012 so this should be treated like another IE message coming in with no movement and audited as a failure.