### PR TITLE
[EMCS-622] add consignee to ern submissions when submit draft movement

### DIFF
--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/DraftExciseMovementController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/DraftExciseMovementController.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.excisemovementcontrolsystemapi.models.messages.{IE815Message,
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.notification.Constants
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.validation._
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.{ErrorResponse, ExciseMovementResponse}
-import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.BoxIdRepository
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.{BoxIdRepository, ErnSubmissionRepository}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 import uk.gov.hmrc.excisemovementcontrolsystemapi.services._
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.DateTimeService
@@ -49,6 +49,7 @@ class DraftExciseMovementController @Inject() (
   dateTimeService: DateTimeService,
   auditService: AuditService,
   boxIdRepository: BoxIdRepository,
+  ernSubmissionRepository: ErnSubmissionRepository,
   appConfig: AppConfig,
   cc: ControllerComponents
 )(implicit ec: ExecutionContext)
@@ -113,6 +114,7 @@ class DraftExciseMovementController @Inject() (
         Left(result)
       case Right(movement) =>
         auditService.auditMessage(message)
+        message.consigneeId.map(consignee => ernSubmissionRepository.save(consignee))
         Right(movement)
     })
 

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageService.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageService.scala
@@ -20,7 +20,6 @@ import cats.syntax.all._
 import org.apache.pekko.Done
 import play.api.{Configuration, Logging}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.{MessageConnector, TraderMovementConnector}
-import uk.gov.hmrc.excisemovementcontrolsystemapi.models
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.messages._
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.{Message, Movement}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.{BoxIdRepository, ErnRetrievalRepository, MovementRepository}

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/DraftExciseMovementControllerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/DraftExciseMovementControllerSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.excisemovementcontrolsystemapi.controllers
 
 import cats.data.EitherT
+import org.apache.pekko.Done
 import org.mockito.ArgumentMatchersSugar.{any, eqTo}
 import org.mockito.MockitoSugar.{reset, times, verify, verifyZeroInteractions, when}
 import org.mockito.captor.ArgCaptor
@@ -36,7 +37,7 @@ import uk.gov.hmrc.excisemovementcontrolsystemapi.models.auth.ParsedXmlRequest
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.eis.EISSubmissionResponse
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.messages.{IE815Message, IE818Message}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.validation.{MessageIdentifierIsUnauthorised, MessageValidation}
-import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.BoxIdRepository
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.{BoxIdRepository, ErnSubmissionRepository}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.Movement
 import uk.gov.hmrc.excisemovementcontrolsystemapi.services._
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.DateTimeService
@@ -61,6 +62,7 @@ class DraftExciseMovementControllerSpec
   private val request                  = createRequestWithClientId
   private val mockIeMessage            = mock[IE815Message]
   private val boxIdRepository          = mock[BoxIdRepository]
+  private val ernSubmissionRepository  = mock[ErnSubmissionRepository]
   private val notificationService      = mock[PushNotificationService]
   private val messageValidation        = mock[MessageValidation]
   private val dateTimeService          = mock[DateTimeService]
@@ -79,7 +81,8 @@ class DraftExciseMovementControllerSpec
       submissionMessageService,
       notificationService,
       auditService,
-      boxIdRepository
+      boxIdRepository,
+      ernSubmissionRepository
     )
 
     when(submissionMessageService.submit(any, any)(any))
@@ -97,6 +100,7 @@ class DraftExciseMovementControllerSpec
     when(appConfig.pushNotificationsEnabled).thenReturn(true)
     when(dateTimeService.timestamp()).thenReturn(timestamp)
     when(auditService.auditMessage(any)(any)).thenReturn(EitherT.fromEither(Right(())))
+    when(ernSubmissionRepository.save(any)).thenReturn(Future.successful(Done))
   }
 
   "submit" should {
@@ -336,6 +340,7 @@ class DraftExciseMovementControllerSpec
       dateTimeService,
       auditService,
       boxIdRepository,
+      ernSubmissionRepository,
       appConfig,
       cc
     )
@@ -352,6 +357,7 @@ class DraftExciseMovementControllerSpec
       dateTimeService,
       auditService,
       boxIdRepository,
+      ernSubmissionRepository,
       appConfig,
       cc
     )
@@ -367,6 +373,7 @@ class DraftExciseMovementControllerSpec
       dateTimeService,
       auditService,
       boxIdRepository,
+      ernSubmissionRepository,
       appConfig,
       cc
     )
@@ -382,6 +389,7 @@ class DraftExciseMovementControllerSpec
       dateTimeService,
       auditService,
       boxIdRepository,
+      ernSubmissionRepository,
       appConfig,
       cc
     )


### PR DESCRIPTION
This ensures that the consignee starts getting polled for as soon as the draft is submitted.
This means that we receive the IE801 for both
This is crucial for the IE813 scenario as the consignee may change one the movement and if updateMessages is not triggered before that happens, without having the IE801 for the original consignee, this message will then be retrieved when updateMessages is triggered for the old consignee and a new movement potentially created from that IE801