### PR TITLE
[EMCS-630] Fix for E2E bug 771

### DIFF
--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
@@ -132,8 +132,10 @@ class GetMovementsController @Inject() (
       )
     )
 
-  private def getErnsForMovement(movement: Movement): Set[String] =
-    Set(Some(movement.consignorId), movement.consigneeId).flatten
+  private def getErnsForMovement(movement: Movement): Set[String] = {
+    val messageRecipients = movement.messages.map(_.recipient)
+    Set(Some(movement.consignorId), movement.consigneeId, messageRecipients).flatten
+  }
 
   private def createResponseFrom(movement: Movement) =
     ExciseMovementResponse(

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
@@ -132,8 +132,10 @@ class MovementRepository @Inject() (
 
     val ernFilters = Seq(
       Filters.in("consignorId", ern: _*),
-      Filters.in("consigneeId", ern: _*)
+      Filters.in("consigneeId", ern: _*),
+      Filters.in("messages.recipient", ern: _*)
     )
+
     val filters    =
       Seq(
         movementFilter.updatedSince.map(Filters.gte("lastUpdated", _)),
@@ -260,6 +262,11 @@ object MovementRepository {
         Indexes.ascending("messages.boxesToNotify"),
         IndexOptions()
           .name("boxesToNotify_idx")
+      ),
+      IndexModel(
+        Indexes.ascending("messages.recipient"),
+        IndexOptions()
+          .name("recipient_idx")
       )
     )
 

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
@@ -141,7 +141,10 @@ class MovementRepository @Inject() (
         movementFilter.updatedSince.map(Filters.gte("lastUpdated", _)),
         movementFilter.lrn.map(Filters.eq("localReferenceNumber", _)),
         movementFilter.arc.map(Filters.eq("administrativeReferenceCode", _)),
-        movementFilter.ern.map(ern => Filters.or(Filters.eq("consignorId", ern), Filters.eq("consigneeId", ern)))
+        movementFilter.ern.map(ern =>
+          Filters
+            .or(Filters.eq("consignorId", ern), Filters.eq("consigneeId", ern), Filters.eq("messages.recipient", ern))
+        )
       ).flatten
 
     val filter = if (filters.nonEmpty) Filters.and(filters: _*) else Filters.empty()

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
@@ -160,6 +160,14 @@ class MovementRepository @Inject() (
     getMovementByERN(Seq(ern), MovementFilter.emptyFilter)
   }
 
+  def getByArc(arc: String): Future[Option[Movement]] = Mdc.preservingMdc {
+    collection
+      .find(
+        filter = Filters.equal("administrativeReferenceCode", arc)
+      )
+      .headOption()
+  }
+
   def getErnsAndLastReceived: Future[Map[String, Instant]] = Mdc.preservingMdc {
     collection
       .aggregate[ErnAndLastReceived](

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
@@ -136,7 +136,7 @@ class MovementRepository @Inject() (
       Filters.in("messages.recipient", ern: _*)
     )
 
-    val filters    =
+    val filters =
       Seq(
         movementFilter.updatedSince.map(Filters.gte("lastUpdated", _)),
         movementFilter.lrn.map(Filters.eq("localReferenceNumber", _)),

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
@@ -299,6 +299,28 @@ class MovementRepositoryItSpec
     mustPreserveMdc(repository.findDraftMovement(movement))
   }
 
+
+  "getByArc" should {
+    val lrn                   = "123"
+    val consignorId           = "Abc"
+    val consigneeId           = "def"
+    val arc                   = "arc1"
+    val movement              = Movement(Some("boxId"), lrn, consignorId, Some(consigneeId), Some(arc), lastUpdated = timestamp)
+    "return None if no matching movement" in {
+      val result = repository.getByArc(arc).futureValue
+
+      result mustBe None
+    }
+    "return the existing movement matching the ARC" in {
+      insertMovement(movement)
+
+      val result = repository.getByArc(arc).futureValue
+
+      result mustBe Some(movement)
+    }
+    mustPreserveMdc(repository.getByArc(arc))
+  }
+
   "getMovementByErn" should {
     "return a list of movement" when {
       "ern match the consignorId " in {

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
@@ -539,6 +539,26 @@ class MovementRepositoryItSpec
 
     }
 
+    "return a movement" when {
+      "the movement doesn't contain the ERN in consignee or consignor, but a message on the movement does" in {
+        val messages = Seq(Message("blah","IE801","MessageId", "Recipient", Set.empty, timestamp))
+        val expectedMovement1 = Movement(
+          Some("boxId"),
+          "1",
+          "consignor",
+          Some("consignee"),
+          Some("arc1"),
+          lastUpdated = timestamp,
+          messages = messages
+        )
+        insertMovement(expectedMovement1)
+
+        val result = repository.getMovementByERN(Seq("Recipient")).futureValue
+
+        result mustBe Seq(expectedMovement1)
+      }
+    }
+
     "return an empty list" in {
       val expectedMovement1 =
         Movement(Some("boxId"), "lrn", "consignorId1", Some("ern1"), Some("arc1"), lastUpdated = timestamp)

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
@@ -380,6 +380,39 @@ class MovementRepositoryItSpec
         )
 
       }
+      "ern from filter matches record from database" when {
+        val allErns = Seq("consignor", "consignee", "recipient")
+        "ern is consignor" in {
+          val consignorMovement =
+            Movement(Some("boxId"), "1", "consignor", Some("ern1"), Some("arc1"), lastUpdated = timestamp)
+          insertMovement(consignorMovement)
+          val result =
+            repository.getMovementByERN(allErns, MovementFilter.emptyFilter.copy(ern = Some("consignor"))).futureValue
+          result mustBe Seq(
+            consignorMovement
+          )
+        }
+        "ern is consignee" in {
+          val consigneeMovement =
+            Movement(Some("boxId"), "2", "ern1", Some("consignee"), Some("arc2"), lastUpdated = timestamp)
+          insertMovement(consigneeMovement)
+          val result =
+            repository.getMovementByERN(allErns, MovementFilter.emptyFilter.copy(ern = Some("consignee"))).futureValue
+          result mustBe Seq(
+            consigneeMovement
+          )
+        }
+        "ern is message recipient" in {
+          val recipientMovement =
+            Movement(Some("boxId"), "3", "consignorId1", Some("ern1"), Some("arc3"), lastUpdated = timestamp, messages = Seq(Message("encoded", "IE801", "Id", "recipient", Set.empty, timestamp)))
+          insertMovement(recipientMovement)
+          val result =
+            repository.getMovementByERN(allErns, MovementFilter.emptyFilter.copy(ern = Some("recipient"))).futureValue
+          result mustBe Seq(
+            recipientMovement
+          )
+        }
+      }
 
       "arc from filter matches record from database" in {
         val expectedMovement1 =

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsControllerSpec.scala
@@ -341,8 +341,16 @@ class GetMovementsControllerSpec
     "return the movement if the ern is in the message recipients" in {
 
       val movement =
-        Movement(uuid, Some("id123"), "lrn1", "consignor", Some("consignee"), Some("arc"), Instant.now(),
-          Seq(Message("message","IE801","messageId", ern, Set.empty, timestamp)))
+        Movement(
+          uuid,
+          Some("id123"),
+          "lrn1",
+          "consignor",
+          Some("consignee"),
+          Some("arc"),
+          Instant.now(),
+          Seq(Message("message", "IE801", "messageId", ern, Set.empty, timestamp))
+        )
 
       when(movementIdValidator.validateMovementId(eqTo(uuid))).thenReturn(Right(uuid))
       when(movementService.getMovementById(any)).thenReturn(Future.successful(Some(movement)))


### PR DESCRIPTION
This updates the movement if an IE801 is received with a different consignee but for the same ARC. This i what happens when an IE813 is submitted in the EU, we won't have sight of the IE813, but we will have sight of the IE801 for the new consignee.

This also fixes the permission to access the movement/messages to also consider erns that aren't the consignor or the consignee of the movement but are marked as a recipient for one of the messages in the movement.