### PR TITLE
Notification apis

### DIFF
--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/GetMovementsController.scala
@@ -54,7 +54,7 @@ class GetMovementsController @Inject() (
     arc: Option[String],
     updatedSince: Option[String],
     traderType: Option[String]
-  ): Action[AnyContent]                                                                                         =
+  ): Action[AnyContent]                                   =
     (authAction andThen validateErnParameterAction(ern)
       andThen validateUpdatedSinceAction(updatedSince)
       andThen validateTraderTypeAction(traderType)).async(parse.default) { implicit request =>
@@ -75,7 +75,7 @@ class GetMovementsController @Inject() (
           Ok(Json.toJson(movement.map(createResponseFrom)))
         }
     }
-  def getMovement(movementId: String): Action[AnyContent]                                                       =
+  def getMovement(movementId: String): Action[AnyContent] =
     authAction.async(parse.default) { implicit request =>
       val result = for {
         validatedMovementId <- validateMovementId(movementId)

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/ClientBoxIdRepository.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/ClientBoxIdRepository.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.excisemovementcontrolsystemapi.repository
+
+import org.apache.pekko.Done
+import org.mongodb.scala.model._
+import play.api.Configuration
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.ClientBoxIdRepository.mongoIndexes
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.ClientBoxId
+import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.DateTimeService
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import uk.gov.hmrc.play.http.logging.Mdc
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ClientBoxIdRepository @Inject()(
+  mongo: MongoComponent,
+  configuration: Configuration,
+  timeService: DateTimeService
+)(implicit ec: ExecutionContext)
+    extends PlayMongoRepository[ClientBoxId](
+      collectionName = "clientboxids",
+      mongoComponent = mongo,
+      domainFormat = ClientBoxId.format,
+      indexes = mongoIndexes(configuration.get[Duration]("mongodb.clientBoxId.TTL")),
+      replaceIndexes = false
+    ) {
+
+  def getBoxId(clientId: String): Future[Option[String]] = Mdc.preservingMdc {
+    collection.find(
+      Filters.eq("clientId", clientId)
+    )
+      .map(_.boxId)
+      .headOption()
+  }
+
+  def save(clientId: String, boxId: String): Future[Done] = Mdc.preservingMdc {
+    collection
+      .insertOne(
+        ClientBoxId(clientId, boxId, timeService.timestamp())
+      )
+      .toFuture()
+      .map(_ => Done)
+  }
+}
+
+object ClientBoxIdRepository {
+  def mongoIndexes(ttl: Duration): Seq[IndexModel] =
+    Seq(
+      IndexModel(
+        Indexes.ascending("createdOn"),
+        IndexOptions()
+          .name("createdOn_ttl_idx")
+          .expireAfter(ttl.length, ttl.unit)
+      ),
+      IndexModel(
+        Indexes.ascending("clientId"),
+        IndexOptions()
+          .name("clientId_idx")
+          .unique(true)
+      ),
+    )
+}

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/ClientBoxIdRepository.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/ClientBoxIdRepository.scala
@@ -31,7 +31,7 @@ import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class ClientBoxIdRepository @Inject()(
+class ClientBoxIdRepository @Inject() (
   mongo: MongoComponent,
   configuration: Configuration,
   timeService: DateTimeService
@@ -45,9 +45,10 @@ class ClientBoxIdRepository @Inject()(
     ) {
 
   def getBoxId(clientId: String): Future[Option[String]] = Mdc.preservingMdc {
-    collection.find(
-      Filters.eq("clientId", clientId)
-    )
+    collection
+      .find(
+        Filters.eq("clientId", clientId)
+      )
       .map(_.boxId)
       .headOption()
   }
@@ -76,6 +77,6 @@ object ClientBoxIdRepository {
         IndexOptions()
           .name("clientId_idx")
           .unique(true)
-      ),
+      )
     )
 }

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/model/ClientBoxId.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/model/ClientBoxId.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model
+
+import play.api.libs.json.{Format, Json, OFormat}
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
+
+import java.time.Instant
+
+case class ClientBoxId(clientId: String, boxId: String, createdOn: Instant)
+
+object ClientBoxId {
+  implicit val instantFormat: Format[Instant] = MongoJavatimeFormats.instantFormat
+
+  implicit lazy val format: OFormat[ClientBoxId] = Json.format
+}

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageService.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageService.scala
@@ -129,7 +129,7 @@ class MessageService @Inject() (
             .foldLeft(Future.successful(Seq.empty[Movement])) { (accumulated, message) =>
               for {
                 accumulatedMovements <- accumulated
-                updatedMovements <- updateOrCreateMovements(ern, movements, accumulatedMovements, message, boxIds)
+                updatedMovements     <- updateOrCreateMovements(ern, movements, accumulatedMovements, message, boxIds)
               } yield (updatedMovements ++ accumulatedMovements)
                 .distinctBy { movement =>
                   (movement.localReferenceNumber, movement.consignorId, movement.administrativeReferenceCode)

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NotificationsService.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NotificationsService.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.excisemovementcontrolsystemapi.services
+
+import cats.implicits.toTraverseOps
+import org.apache.pekko.Done
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.{BoxIdRepository, ClientBoxIdRepository}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class NotificationsService @Inject() (
+  clientBoxIdRepository: ClientBoxIdRepository,
+  boxIdRepository: BoxIdRepository,
+  pushNotificationService: PushNotificationService
+                                     )(implicit hc: HeaderCarrier, ec: ExecutionContext) {
+  def subscribeErns(clientId: String, erns: Seq[String]): Future[Done] = {
+    clientBoxIdRepository.getBoxId(clientId).flatMap { maybeBoxId =>
+      val boxId = maybeBoxId.getOrElse {
+        val box = pushNotificationService.getBoxId(clientId)
+          box.map(x => x.map(y => {
+          clientBoxIdRepository.save(clientId, y)
+          y
+        }))
+        box
+      }
+      erns.traverse { ern =>
+        boxIdRepository.save(ern, boxId)
+      }.as(Done)
+    }
+  }
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -83,6 +83,10 @@ mongodb {
   boxId {
     TTL = 30 days
   }
+
+  clientBoxId {
+    TTL = 30 days
+  }
 }
 
 scheduler {

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/ClientBoxIdRepositoryItSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/ClientBoxIdRepositoryItSpec.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.excisemovementcontrolsystemapi.repository
+
+import com.mongodb.MongoWriteException
+import org.mockito.MockitoSugar.when
+import org.mongodb.scala.model.{Filters, Indexes}
+import org.scalactic.source.Position
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatestplus.mockito.MockitoSugar.mock
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import org.slf4j.MDC
+import play.api.Application
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.ClientBoxId
+import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.DateTimeService
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+import scala.concurrent.{ExecutionContext, Future}
+
+
+class ClientBoxIdRepositoryItSpec extends PlaySpec
+  with DefaultPlayMongoRepositorySupport[ClientBoxId]
+  with IntegrationPatience
+  with GuiceOneAppPerSuite {
+
+  private val mockTimeService = mock[DateTimeService]
+
+  override def fakeApplication(): Application = GuiceApplicationBuilder()
+    .overrides(
+      bind[MongoComponent].toInstance(mongoComponent),
+      bind[DateTimeService].toInstance(mockTimeService)
+    )
+    .configure(
+      "mongodb.clientBoxId.TTL" -> "5 minutes"
+    ).build()
+
+  override protected lazy val repository: ClientBoxIdRepository = app.injector.instanceOf[ClientBoxIdRepository]
+
+  "initialise" should {
+    "setup the createdOn index" in {
+      val createdOnIdx = repository.indexes.find(_.getOptions.getName == "createdOn_ttl_idx").value
+      createdOnIdx.getOptions.getExpireAfter(TimeUnit.MINUTES) mustBe 5
+      createdOnIdx.getKeys mustEqual Indexes.ascending("createdOn")
+    }
+    "setup the clientId index" in {
+      val ern = repository.indexes.find(_.getOptions.getName == "clientId_idx").value
+      ern.getOptions.isUnique mustBe true
+      ern.getKeys mustEqual Indexes.ascending("clientId")
+    }
+  }
+
+  "save" should {
+    "save when there isn't one there already" in {
+      val fixedInstant = Instant.now.truncatedTo(ChronoUnit.MILLIS)
+      when(mockTimeService.timestamp()).thenReturn(fixedInstant)
+
+      repository.save("testClient", "testBox").futureValue
+
+      find(Filters.eq("clientId", "testClient")).futureValue.head mustBe ClientBoxId("testClient", "testBox", fixedInstant)
+    }
+
+    "throw a MongoWriteException if there's already a record in the database" in {
+      val fixedInstant = Instant.now.truncatedTo(ChronoUnit.MILLIS)
+      when(mockTimeService.timestamp()).thenReturn(fixedInstant)
+
+      insert(ClientBoxId("testClient", "testBox", fixedInstant)).futureValue
+
+      val failure = repository.save("testClient", "testBox2").failed.futureValue
+
+      failure mustBe a [MongoWriteException]
+    }
+
+    mustPreserveMdc(repository.save("testClient", "testBox"))
+  }
+
+  "getBoxId" should {
+
+    "return None if there is no boxId for the client" in {
+      repository.getBoxId("testClient").futureValue mustBe None
+    }
+
+    "return the boxId for the client if there is one" in {
+      val fixedInstant = Instant.now.truncatedTo(ChronoUnit.MILLIS)
+      when(mockTimeService.timestamp()).thenReturn(fixedInstant)
+
+      insert(ClientBoxId("testClient", "testBox", fixedInstant)).futureValue
+
+      val boxId = repository.getBoxId("testClient").futureValue
+      boxId mustBe Some("testBox")
+    }
+
+    mustPreserveMdc(repository.getBoxId("testClient"))
+  }
+
+  private def mustPreserveMdc[A](f: => Future[A])(implicit pos: Position): Unit =
+    "must preserve MDC" in {
+
+      val ec = app.injector.instanceOf[ExecutionContext]
+
+      MDC.put("test", "foo")
+
+      f.map { _ =>
+        MDC.get("test") mustEqual "foo"
+      }(ec).futureValue
+    }
+}

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NotificationsServiceSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NotificationsServiceSpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.excisemovementcontrolsystemapi.services
+
+import org.apache.pekko.Done
+import org.mockito.ArgumentMatchersSugar.{any, eqTo}
+import org.mockito.MockitoSugar.{reset, verify, when}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatestplus.mockito.MockitoSugar.mock
+import org.scalatestplus.play.PlaySpec
+import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.{BoxIdRepository, ClientBoxIdRepository}
+import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.DateTimeService
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class NotificationsServiceSpec
+    extends PlaySpec
+    with ScalaFutures
+    with IntegrationPatience
+    with BeforeAndAfterEach {
+
+  private val clientBoxIdRepository   = mock[ClientBoxIdRepository]
+  private val boxIdRepository         = mock[BoxIdRepository]
+  private val pushNotificationService = mock[PushNotificationService]
+  private val dateTimeService         = mock[DateTimeService]
+
+  private val notificationsService = new NotificationsService(
+    clientBoxIdRepository,
+    boxIdRepository,
+    pushNotificationService)
+
+  private implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(
+      clientBoxIdRepository,
+      boxIdRepository,
+      pushNotificationService,
+      dateTimeService,
+    )
+  }
+
+  "subscribe ERNs for client id" when {
+    "subscribes all erns to the client's box Id" when {
+      "the client's boxId isn't in the cache" when {
+        "gets the client's default box and adds to the cache" in {
+          val clientId = "testClient"
+          val boxId = "testBox"
+          val consignor = "consignor"
+          val consignee = "consignee"
+          when(clientBoxIdRepository.getBoxId(any)).thenReturn(Future.successful(None))
+          when(clientBoxIdRepository.save(any, any)).thenReturn(Future.successful(Done))
+          when(pushNotificationService.getBoxId(any, any)(any)).thenReturn(Future.successful(Right(boxId)))
+          when(boxIdRepository.save(any, any)).thenReturn(Future.successful(Done))
+
+          notificationsService.subscribeErns(clientId, Seq(consignor, consignee))
+
+          verify(clientBoxIdRepository).getBoxId(clientId)
+          verify(pushNotificationService).getBoxId(eqTo(clientId), eqTo(None))(any)
+          verify(clientBoxIdRepository.save(clientId, boxId))
+          verify(boxIdRepository.save(consignor, boxId))
+          verify(boxIdRepository.save(consignee, boxId))
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**TODO**
- [ ] Sort out notificationsService to subscribe ERNs
       We first try to get the boxId for the client out of the cache, if it doesn't exist we want to get it using the default box from PPNS and save in the cache. For the boxId, add all the ERNs in the boxIdRepository.
- [ ] Sort out the unsubscribe, follow same pattern above to get boxId and remove each ERN  for that boxId in the boxIdsRepository
- [ ] Create Controller
- [ ] Add a `user-restricted` route to subscribe all ERNs (take all ERNs out of token but also have a body to allow ERNs to be passed (each ERN must also be in the token), otherwise just use all in token). Call service to subscribe ERNs.
- [ ] Return 401 if not correct token
- [ ] Return 403 if ERNs in body don't match token
- [ ] Add a `app-restricted` route to unsubscribe a list of erns from a body (array of ERNs). Application restricted means the SWD won't need the token to remove the ERNs from their boxId. Call service to unsubscribe ERNs
- [ ] Add routes to app.routes
- [ ] Add routes to application.yaml (API spec)


