### PR TITLE
Emcs 633 scheduler wiring

### DIFF
--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/config/Module.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/config/Module.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.excisemovementcontrolsystemapi.config
 import play.api.inject.Binding
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsCircuitBreakerProvider
-import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnector.NrsCircuitBreaker
+import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnectorNew.NrsCircuitBreaker
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.{MessageRecipientMigration, MovementMigration}
 import uk.gov.hmrc.mongo.metrix.MetricOrchestrator
 
@@ -34,7 +34,7 @@ class Module extends play.api.inject.Module {
       bind[Clock].toInstance(Clock.systemUTC()),
       bind[MetricOrchestrator].toProvider[MetricsProvider],
       bind[NrsCircuitBreaker].toProvider[NrsCircuitBreakerProvider]
-  ) ++ migrationBindings(configuration)
+    ) ++ migrationBindings(configuration)
 
   private def migrationBindings(configuration: Configuration): Seq[Binding[_]] =
     if (configuration.get[Boolean]("migrations-enabled")) {

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/config/Module.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/config/Module.scala
@@ -18,6 +18,8 @@ package uk.gov.hmrc.excisemovementcontrolsystemapi.config
 
 import play.api.inject.Binding
 import play.api.{Configuration, Environment}
+import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsCircuitBreakerProvider
+import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnector.NrsCircuitBreaker
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.{MessageRecipientMigration, MovementMigration}
 import uk.gov.hmrc.mongo.metrix.MetricOrchestrator
 
@@ -30,8 +32,9 @@ class Module extends play.api.inject.Module {
       bind[AppConfig].toSelf.eagerly(),
       bind[JobScheduler].toSelf.eagerly(),
       bind[Clock].toInstance(Clock.systemUTC()),
-      bind[MetricOrchestrator].toProvider[MetricsProvider]
-    ) ++ migrationBindings(configuration)
+      bind[MetricOrchestrator].toProvider[MetricsProvider],
+      bind[NrsCircuitBreaker].toProvider[NrsCircuitBreakerProvider]
+  ) ++ migrationBindings(configuration)
 
   private def migrationBindings(configuration: Configuration): Seq[Binding[_]] =
     if (configuration.get[Boolean]("migrations-enabled")) {

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsCircuitBreakerProvider.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsCircuitBreakerProvider.scala
@@ -1,0 +1,37 @@
+package uk.gov.hmrc.excisemovementcontrolsystemapi.connectors
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.pattern.CircuitBreaker
+import play.api.{Configuration, Logging}
+import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnector.NrsCircuitBreaker
+
+import javax.inject.{Inject, Provider, Singleton}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+
+@Singleton
+class NrsCircuitBreakerProvider @Inject()(
+                                            configuration: Configuration,
+                                            system: ActorSystem
+                                          )(implicit ec: ExecutionContext) extends Provider[NrsCircuitBreaker] with Logging {
+
+  private val maxFailures: Int = configuration.get[Int]("nrs.max-failures")
+  private val callTimeout: FiniteDuration = configuration.get[FiniteDuration]("nrs.call-timeout")
+  private val resetTimeout: FiniteDuration = configuration.get[FiniteDuration]("nrs.reset-timeout")
+
+  private val breaker: CircuitBreaker =
+    new CircuitBreaker(
+      scheduler = system.scheduler,
+      maxFailures = maxFailures,
+      callTimeout = callTimeout,
+      resetTimeout = resetTimeout
+    )
+      .onOpen {
+        logger.warn("NRS Circuit Breaker has opened")
+      }
+      .onClose {
+        logger.info("NRS Circuit Breaker has closed")
+      }
+
+  override def get(): NrsCircuitBreaker = NrsCircuitBreaker(breaker)
+}

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsCircuitBreakerProvider.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsCircuitBreakerProvider.scala
@@ -1,22 +1,40 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.excisemovementcontrolsystemapi.connectors
 
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.pattern.CircuitBreaker
 import play.api.{Configuration, Logging}
-import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnector.NrsCircuitBreaker
+import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnectorNew.NrsCircuitBreaker
 
 import javax.inject.{Inject, Provider, Singleton}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 @Singleton
-class NrsCircuitBreakerProvider @Inject()(
-                                            configuration: Configuration,
-                                            system: ActorSystem
-                                          )(implicit ec: ExecutionContext) extends Provider[NrsCircuitBreaker] with Logging {
+class NrsCircuitBreakerProvider @Inject() (
+  configuration: Configuration,
+  system: ActorSystem
+)(implicit ec: ExecutionContext)
+    extends Provider[NrsCircuitBreaker]
+    with Logging {
 
-  private val maxFailures: Int = configuration.get[Int]("nrs.max-failures")
-  private val callTimeout: FiniteDuration = configuration.get[FiniteDuration]("nrs.call-timeout")
+  private val maxFailures: Int             = configuration.get[Int]("nrs.max-failures")
+  private val callTimeout: FiniteDuration  = configuration.get[FiniteDuration]("nrs.call-timeout")
   private val resetTimeout: FiniteDuration = configuration.get[FiniteDuration]("nrs.reset-timeout")
 
   private val breaker: CircuitBreaker =

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnector.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnector.scala
@@ -51,25 +51,25 @@ class NrsConnector @Inject() (
     logger.info(
       s"NRS submission: CorrelationId: $correlationId"
     )
-    val response = httpClient
+    val response         = httpClient
       .post(url"$nrsSubmissionUrl")
       .setHeader("Content-Type" -> "application/json")
-      .setHeader(XApiKeyHeaderKey -> appConfig.nrsApiKey)
+//      .setHeader(XApiKeyHeaderKey -> appConfig.nrsApiKey)
       .withBody(payload.toJsObject)
       .execute[HttpResponse]
 
-    response.flatMap( thing =>
-    if (thing.status == ACCEPTED) {
+    response.flatMap(thing =>
+      if (thing.status == ACCEPTED) {
 //      logging here
-      Future.successful(Done)
-    } else if (is5xx(thing.status)) {
-      // logging here too
-      // circuit breaker trip here
-      Future.failed(UnexpectedResponseException(thing.status, thing.body))
-    } else {
-      ??? // catch all for any other unexpected status inc 4xx
-      // warn log...?
-    }
+        Future.successful(Done)
+      } else if (is5xx(thing.status)) {
+        // logging here too
+        // circuit breaker trip here
+        Future.failed(UnexpectedResponseException(thing.status, thing.body))
+      } else {
+        ??? // catch all for any other unexpected status inc 4xx
+        // warn log...?
+      }
     )
   }
 
@@ -133,7 +133,7 @@ class NrsConnector @Inject() (
 object NrsConnector {
   val XApiKeyHeaderKey = "X-API-Key"
 
-  final case class UnexpectedResponseException(status: Int, body: String) extends Exception{
+  final case class UnexpectedResponseException(status: Int, body: String) extends Exception {
     override def getMessage: String = s"Unexpected response from NRS, status: $status, body: $body"
   }
 

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnector.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnector.scala
@@ -54,7 +54,7 @@ class NrsConnector @Inject() (
     val response         = httpClient
       .post(url"$nrsSubmissionUrl")
       .setHeader("Content-Type" -> "application/json")
-//      .setHeader(XApiKeyHeaderKey -> appConfig.nrsApiKey)
+      .setHeader(XApiKeyHeaderKey -> appConfig.nrsApiKey)
       .withBody(payload.toJsObject)
       .execute[HttpResponse]
 
@@ -67,8 +67,8 @@ class NrsConnector @Inject() (
         // circuit breaker trip here
         Future.failed(UnexpectedResponseException(thing.status, thing.body))
       } else {
-        ??? // catch all for any other unexpected status inc 4xx
-        // warn log...?
+        // warn log...
+        Future.failed(UnexpectedResponseException(thing.status, thing.body))
       }
     )
   }

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnector.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnector.scala
@@ -18,62 +18,30 @@ package uk.gov.hmrc.excisemovementcontrolsystemapi.connectors
 
 import com.codahale.metrics.MetricRegistry
 import org.apache.pekko.Done
-import org.apache.pekko.pattern.CircuitBreaker
 import play.api.Logging
 import play.api.http.Status.ACCEPTED
 import play.api.libs.concurrent.Futures
 import play.api.libs.json.JsObject
 import uk.gov.hmrc.excisemovementcontrolsystemapi.config.AppConfig
-import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnector.{NrsCircuitBreaker, UnexpectedResponseException, XApiKeyHeaderKey}
+import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnectorNew.XApiKeyHeaderKey
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.nrs._
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.Retrying
-import uk.gov.hmrc.http.HttpErrorFunctions.{is2xx, is5xx}
+import uk.gov.hmrc.http.HttpErrorFunctions.is2xx
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
 class NrsConnector @Inject() (
   httpClient: HttpClientV2,
   appConfig: AppConfig,
-  metrics: MetricRegistry,
-  nrsCircuitBreaker: NrsCircuitBreaker
+  metrics: MetricRegistry
 )(implicit val ec: ExecutionContext, val futures: Futures)
     extends Retrying
     with Logging {
-
-  def sendToNrs(payload: NrsPayload, correlationId: String)(implicit
-    hc: HeaderCarrier
-  ): Future[Done] = {
-
-    val nrsSubmissionUrl = appConfig.getNrsSubmissionUrl
-    logger.info(
-      s"NRS submission: CorrelationId: $correlationId"
-    )
-    def responseStatusAsFailure(): Try[HttpResponse] => Boolean = {
-      case Success(n) => is5xx(n.status)
-      case Failure(_) => true
-    }
-
-    nrsCircuitBreaker.breaker.withCircuitBreaker({
-      httpClient
-        .post(url"$nrsSubmissionUrl")
-        .setHeader("Content-Type" -> "application/json")
-        .setHeader(XApiKeyHeaderKey -> appConfig.nrsApiKey)
-        .withBody(payload.toJsObject)
-        .execute[HttpResponse]
-    }, responseStatusAsFailure())
-      .flatMap { response =>
-        if(!is5xx(response.status)) {
-          Future.successful(Done)
-        } else {
-          Future.failed(UnexpectedResponseException(response.status, response.body))
-        }
-      }
-  }
 
   def sendToNrsOld(payload: NrsPayload, correlationId: String)(implicit
     hc: HeaderCarrier
@@ -130,14 +98,4 @@ class NrsConnector @Inject() (
       "Content-Type" -> "application/json",
       (XApiKeyHeaderKey, appConfig.nrsApiKey)
     )
-}
-
-object NrsConnector {
-  val XApiKeyHeaderKey = "X-API-Key"
-
-  final case class UnexpectedResponseException(status: Int, body: String) extends Exception {
-    override def getMessage: String = s"Unexpected response from NRS, status: $status, body: $body"
-  }
-
-  final case class NrsCircuitBreaker(breaker: CircuitBreaker)
 }

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnector.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnector.scala
@@ -18,12 +18,13 @@ package uk.gov.hmrc.excisemovementcontrolsystemapi.connectors
 
 import com.codahale.metrics.MetricRegistry
 import org.apache.pekko.Done
+import org.apache.pekko.pattern.CircuitBreaker
 import play.api.Logging
 import play.api.http.Status.ACCEPTED
 import play.api.libs.concurrent.Futures
 import play.api.libs.json.JsObject
 import uk.gov.hmrc.excisemovementcontrolsystemapi.config.AppConfig
-import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnector.{UnexpectedResponseException, XApiKeyHeaderKey}
+import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnector.{NrsCircuitBreaker, UnexpectedResponseException, XApiKeyHeaderKey}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.nrs._
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.Retrying
 import uk.gov.hmrc.http.HttpErrorFunctions.{is2xx, is5xx}
@@ -38,7 +39,8 @@ import scala.util.{Success, Try}
 class NrsConnector @Inject() (
   httpClient: HttpClientV2,
   appConfig: AppConfig,
-  metrics: MetricRegistry
+  metrics: MetricRegistry,
+  nrsCircuitBreaker: NrsCircuitBreaker
 )(implicit val ec: ExecutionContext, val futures: Futures)
     extends Retrying
     with Logging {
@@ -137,5 +139,5 @@ object NrsConnector {
     override def getMessage: String = s"Unexpected response from NRS, status: $status, body: $body"
   }
 
-//  final case class SdesCircuitBreaker(breaker: CircuitBreaker)
+  final case class NrsCircuitBreaker(breaker: CircuitBreaker)
 }

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorNew.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorNew.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.excisemovementcontrolsystemapi.connectors
+
+import com.codahale.metrics.MetricRegistry
+import org.apache.pekko.Done
+import org.apache.pekko.pattern.CircuitBreaker
+import play.api.Logging
+import play.api.libs.concurrent.Futures
+import uk.gov.hmrc.excisemovementcontrolsystemapi.config.AppConfig
+import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnectorNew.{NrsCircuitBreaker, UnexpectedResponseException, XApiKeyHeaderKey}
+import uk.gov.hmrc.excisemovementcontrolsystemapi.models.nrs._
+import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.Retrying
+import uk.gov.hmrc.http.HttpErrorFunctions.is5xx
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+class NrsConnectorNew @Inject() (
+  httpClient: HttpClientV2,
+  appConfig: AppConfig,
+  metrics: MetricRegistry,
+  nrsCircuitBreaker: NrsCircuitBreaker
+)(implicit val ec: ExecutionContext, val futures: Futures)
+    extends Retrying
+    with Logging {
+
+  def sendToNrs(payload: NrsPayload, correlationId: String)(implicit
+    hc: HeaderCarrier
+  ): Future[Done] = {
+
+    val nrsSubmissionUrl                                        = appConfig.getNrsSubmissionUrl
+    logger.info(
+      s"NRS submission: CorrelationId: $correlationId"
+    )
+    def responseStatusAsFailure(): Try[HttpResponse] => Boolean = {
+      case Success(n) => is5xx(n.status)
+      case Failure(_) => true
+    }
+
+    nrsCircuitBreaker.breaker
+      .withCircuitBreaker(
+        httpClient
+          .post(url"$nrsSubmissionUrl")
+          .setHeader("Content-Type" -> "application/json")
+          .setHeader(XApiKeyHeaderKey -> appConfig.nrsApiKey)
+          .withBody(payload.toJsObject)
+          .execute[HttpResponse],
+        responseStatusAsFailure()
+      )
+      .flatMap { response =>
+        if (!is5xx(response.status)) {
+          Future.successful(Done)
+        } else {
+          Future.failed(UnexpectedResponseException(response.status, response.body))
+        }
+      }
+  }
+
+}
+
+object NrsConnectorNew {
+  val XApiKeyHeaderKey = "X-API-Key"
+
+  final case class UnexpectedResponseException(status: Int, body: String) extends Exception {
+    override def getMessage: String = s"Unexpected response from NRS, status: $status, body: $body"
+  }
+
+  final case class NrsCircuitBreaker(breaker: CircuitBreaker)
+}

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/NRSWorkItemRepository.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/NRSWorkItemRepository.scala
@@ -21,6 +21,7 @@ import play.api.Configuration
 import uk.gov.hmrc.excisemovementcontrolsystemapi.config.AppConfig
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.NRSWorkItemRepository.mongoIndexes
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.NrsSubmissionWorkItem
+import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.DateTimeService
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.workitem.{WorkItemFields, WorkItemRepository}
 
@@ -33,7 +34,8 @@ import scala.concurrent.duration.Duration
 @Singleton
 class NRSWorkItemRepository @Inject() (
   appConfig: AppConfig,
-  mongoComponent: MongoComponent
+  mongoComponent: MongoComponent,
+  timeService: DateTimeService
 )(implicit ec: ExecutionContext)
     extends WorkItemRepository[NrsSubmissionWorkItem](
       collectionName = "nrsSubmissionWorkItems",
@@ -46,7 +48,7 @@ class NRSWorkItemRepository @Inject() (
   override def inProgressRetryAfter: JavaDuration =
     appConfig.nrsRetryAfter
 
-  override def now(): Instant = Instant.now()
+  override def now(): Instant = timeService.timestamp()
 }
 
 object NRSWorkItemRepository {

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/NrsSubmissionScheduler.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/NrsSubmissionScheduler.scala
@@ -19,18 +19,17 @@ package uk.gov.hmrc.excisemovementcontrolsystemapi.scheduling
 import cats.implicits.toFunctorOps
 import play.api.{Configuration, Logging}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.NRSWorkItemRepository
-import uk.gov.hmrc.excisemovementcontrolsystemapi.services.NrsService
+import uk.gov.hmrc.excisemovementcontrolsystemapi.services.NrsServiceNew
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.DateTimeService
 import uk.gov.hmrc.http.HeaderCarrier
 
-import java.time.Instant
 import javax.inject.Inject
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future}
 
 class NrsSubmissionScheduler @Inject() (
   nrsWorkItemRepository: NRSWorkItemRepository,
-  nrsService: NrsService,
+  nrsService: NrsServiceNew,
   configuration: Configuration,
   dateTimeService: DateTimeService
 ) extends ScheduledJob

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsService.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsService.scala
@@ -82,7 +82,7 @@ class NrsService @Inject() (
   def submitNrs(workItem: WorkItem[NrsSubmissionWorkItem])(implicit hc: HeaderCarrier): Future[Done] =
     //needs to call connector, and handle marking the workitems. IN PROGRESS
     for {
-      _ <- nrsConnector.sendToNrsOld(workItem.item.payload, correlationIdService.generateCorrelationId())
+      _ <- nrsConnector.sendToNrs(workItem.item.payload, correlationIdService.generateCorrelationId())
       _ <- nrsWorkItemRepository.complete(workItem.id, ProcessingStatus.Succeeded)
     } yield Done
 

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceNew.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceNew.scala
@@ -127,30 +127,3 @@ class NrsServiceNew @Inject() (
         throw new InternalServerException("No auth token available for NRS")
     }
 }
-
-object NrsServiceNew {
-
-  type NonRepudiationIdentityRetrievals =
-    (Option[AffinityGroup] ~ Option[String]
-      ~ Option[String] ~ Option[String]
-      ~ Option[Credentials] ~ ConfidenceLevel
-      ~ Option[String] ~ Option[String]
-      ~ Option[Name]
-      ~ Option[String] ~ AgentInformation
-      ~ Option[String] ~ Option[CredentialRole]
-      ~ Option[MdtpInformation] ~ Option[ItmpName]
-      ~ Option[ItmpAddress]
-      ~ Option[String])
-
-  val nonRepudiationIdentityRetrievals: Retrieval[NonRepudiationIdentityRetrievals] =
-    Retrievals.affinityGroup and Retrievals.internalId and
-      Retrievals.externalId and Retrievals.agentCode and
-      Retrievals.credentials and Retrievals.confidenceLevel and
-      Retrievals.nino and Retrievals.saUtr and
-      Retrievals.name and
-      Retrievals.email and Retrievals.agentInformation and
-      Retrievals.groupIdentifier and Retrievals.credentialRole and
-      Retrievals.mdtpInformation and Retrievals.itmpName and
-      Retrievals.itmpAddress and
-      Retrievals.credentialStrength
-}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -175,6 +175,9 @@ microservice {
       # Defines the number and individual backoff delays for NRS submission retries
       retryDelays = ["1s", "2s", "4s", "8s", "16s", "32s", "64s", "128s", "256s", "512s"]
       retryAfterMinutes = 10
+      max-failures = 10
+      call-timeout = 30 seconds
+      reset-timeout = 10 minutes
     }
 
     push-pull-notifications {

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
@@ -33,11 +33,14 @@ class NrsConnectorSpec
     with NewMessagesXml
     with NrsTestData {
 
-  override def fakeApplication(): Application =
+  override lazy val app: Application =
     GuiceApplicationBuilder()
       .configure(
         "microservice.services.nrs.port" -> wireMockPort,
-        "microservice.services.nrs.api-key" -> "some-bearer"
+        "microservice.services.nrs.api-key" -> "some-bearer",
+        "nrs.max-failures" -> 1,
+        "nrs.reset-timeout" -> "1 second",
+        "nrs.call-timeout" -> "30 seconds"
       )
       .build()
 

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.excisemovementcontrolsystemapi.connectors
 
 import com.github.tomakehurst.wiremock.client.WireMock._
@@ -10,7 +26,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerTest
 import play.api.Application
 import play.api.http.Status.{ACCEPTED, BAD_REQUEST, INTERNAL_SERVER_ERROR}
 import play.api.inject.guice.GuiceApplicationBuilder
-import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnector.{NrsCircuitBreaker, UnexpectedResponseException}
+import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnectorNew.{NrsCircuitBreaker, UnexpectedResponseException}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.fixture.NrsTestData
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.nrs.{NrsMetadata, NrsPayload}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -61,7 +77,7 @@ class NrsConnectorSpec
 
     "must return a Future.successful" - {
       "when the call to NRS succeeds" in {
-        val connector = app.injector.instanceOf[NrsConnector]
+        val connector = app.injector.instanceOf[NrsConnectorNew]
         wireMockServer.stubFor(
           post(urlEqualTo(url))
             .willReturn(
@@ -76,7 +92,7 @@ class NrsConnectorSpec
       }
       "when the call to NRS fails with a 4xx error" - {
         "with circuit breaker present" in {
-          val connector = app.injector.instanceOf[NrsConnector]
+          val connector = app.injector.instanceOf[NrsConnectorNew]
           wireMockServer.stubFor(
             post(urlEqualTo(url))
               .willReturn(
@@ -91,7 +107,7 @@ class NrsConnectorSpec
           result mustBe Done
         }
         "and NOT trip the circuit breaker" in {
-          val connector = app.injector.instanceOf[NrsConnector]
+          val connector = app.injector.instanceOf[NrsConnectorNew]
           val circuitBreaker = app.injector.instanceOf[NrsCircuitBreaker].breaker
 
           circuitBreaker.resetTimeout mustEqual 1.second
@@ -117,7 +133,7 @@ class NrsConnectorSpec
     "must return a failed future" - {
       "when the call to NRS fails with a 5xx error" - {
         "with circuit breaker present" in {
-          val connector = app.injector.instanceOf[NrsConnector]
+          val connector = app.injector.instanceOf[NrsConnectorNew]
           val circuitBreaker = app.injector.instanceOf[NrsCircuitBreaker].breaker
 
           circuitBreaker.resetTimeout mustEqual 1.second
@@ -136,7 +152,7 @@ class NrsConnectorSpec
           exception mustBe UnexpectedResponseException(INTERNAL_SERVER_ERROR, "body")
         }
         "and trip the circuit breaker to fail fast" in {
-          val connector = app.injector.instanceOf[NrsConnector]
+          val connector = app.injector.instanceOf[NrsConnectorNew]
           val circuitBreaker = app.injector.instanceOf[NrsCircuitBreaker].breaker
 
           circuitBreaker.resetTimeout mustEqual 1.second

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
@@ -1,0 +1,100 @@
+package uk.gov.hmrc.excisemovementcontrolsystemapi.connectors
+
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, equalTo, post, urlEqualTo}
+import org.apache.pekko.Done
+import org.mockito.MockitoSugar
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.http.Status.{ACCEPTED, INTERNAL_SERVER_ERROR}
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc.Results.InternalServerError
+import play.api.test.Helpers.await
+import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnector.UnexpectedResponseException
+import uk.gov.hmrc.excisemovementcontrolsystemapi.data.NewMessagesXml
+import uk.gov.hmrc.excisemovementcontrolsystemapi.fixture.NrsTestData
+import uk.gov.hmrc.excisemovementcontrolsystemapi.models.nrs.{NrsMetadata, NrsPayload}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.test.WireMockSupport
+
+import java.time.ZonedDateTime
+import scala.concurrent.Future
+
+class NrsConnectorSpec
+  extends AnyFreeSpec
+    with Matchers
+    with WireMockSupport
+    with GuiceOneAppPerSuite
+    with MockitoSugar
+    with ScalaFutures
+    with IntegrationPatience
+    with BeforeAndAfterEach
+    with NewMessagesXml
+    with NrsTestData {
+
+
+  override lazy val app: Application = {
+    GuiceApplicationBuilder()
+      .configure(
+        "microservice.services.nrs.port" -> wireMockPort,
+        "microservice.services.nrs.api-key" -> "some-bearer"
+      )
+      .overrides(
+      )
+      .build()
+  }
+
+  private lazy val connector = app.injector.instanceOf[NrsConnector]
+
+  "sendToNrs" - {
+
+    val hc = HeaderCarrier()
+    val correlationId = "correlationId"
+    val url = "/submission"
+    val timeStamp                  = ZonedDateTime.now()
+    val nrsMetadata                = NrsMetadata(
+      businessId = "emcs",
+      notableEvent = "excise-movement-control-system",
+      payloadContentType = "application/json",
+      payloadSha256Checksum = sha256Hash("payload for NRS"),
+      userSubmissionTimestamp = timeStamp.toString,
+      identityData = testNrsIdentityData,
+      userAuthToken = testAuthToken,
+      headerData = Map(),
+      searchKeys = Map("ern" -> "123")
+    )
+    val nrsPayLoad                 = NrsPayload("encodepayload", nrsMetadata)
+
+    "must return Done when the call to NRS succeeds" in {
+      wireMockServer.stubFor(
+        post(urlEqualTo(url))
+          .willReturn(
+            aResponse()
+              .withStatus(ACCEPTED)
+          )
+      )
+
+      val result = connector.sendToNrs(nrsPayLoad, correlationId)(hc).futureValue
+
+      result mustBe Done
+    }
+
+    "must return a failed future when the call to NRS fails with a 5xx error" in {
+      wireMockServer.stubFor(
+        post(urlEqualTo(url))
+          .willReturn(
+            aResponse()
+              .withBody("body")
+              .withStatus(INTERNAL_SERVER_ERROR)
+          )
+      )
+
+      val exception = connector.sendToNrs(nrsPayLoad, correlationId)(hc).failed.futureValue
+
+      exception mustBe UnexpectedResponseException(INTERNAL_SERVER_ERROR, "body")
+    }
+  }
+}

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
@@ -79,35 +79,11 @@ class NrsConnectorSpec
     }
     "must return a failed future" - {
       "and trip the circuit breaker" - {
-
-//        val connector = app.injector.instanceOf[SdesConnector]
-//        val circuitBreaker = app.injector.instanceOf[SdesCircuitBreaker].breaker
-//
-//        circuitBreaker.resetTimeout mustEqual 1.second
-//
-//        wireMockServer.stubFor(
-//          post(urlMatching(url))
-//            .withRequestBody(equalToJson(Json.stringify(Json.toJson(request))))
-//            .withHeader("x-client-id", equalTo("client-id"))
-//            .willReturn(aResponse().withBody("body").withStatus(INTERNAL_SERVER_ERROR))
-//        )
-//
-//        val onOpen = Promise[Unit]
-//        circuitBreaker.onOpen(onOpen.success(System.currentTimeMillis()))
-//
-//        circuitBreaker.isOpen mustBe false
-//        connector.notify(request)(using hc).failed.futureValue
-//        onOpen.future.futureValue
-//        circuitBreaker.isOpen mustBe true
-//        connector.notify(request)(using hc).failed.futureValue
-//
-//        wireMockServer.verify(1, postRequestedFor(urlMatching(url)))
-
         "when the call to NRS fails with a 5xx error" in {
           val circuitBreaker = app.injector.instanceOf[NrsCircuitBreaker].breaker
 
           circuitBreaker.resetTimeout mustEqual 1.second
-          
+
           wireMockServer.stubFor(
             post(urlEqualTo(url))
               .willReturn(

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
@@ -1,18 +1,16 @@
 package uk.gov.hmrc.excisemovementcontrolsystemapi.connectors
 
-import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post, postRequestedFor, urlEqualTo, urlMatching}
+import com.github.tomakehurst.wiremock.client.WireMock._
 import org.apache.pekko.Done
 import org.mockito.MockitoSugar
-import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import org.scalatestplus.play.guice.{GuiceOneAppPerSuite, GuiceOneAppPerTest}
+import org.scalatestplus.play.guice.GuiceOneAppPerTest
 import play.api.Application
 import play.api.http.Status.{ACCEPTED, BAD_REQUEST, INTERNAL_SERVER_ERROR}
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnector.{NrsCircuitBreaker, UnexpectedResponseException}
-import uk.gov.hmrc.excisemovementcontrolsystemapi.data.NewMessagesXml
 import uk.gov.hmrc.excisemovementcontrolsystemapi.fixture.NrsTestData
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.nrs.{NrsMetadata, NrsPayload}
 import uk.gov.hmrc.http.HeaderCarrier

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/NRSWorkItemRepositoryItSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/NRSWorkItemRepositoryItSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.excisemovementcontrolsystemapi.repository
 import org.mongodb.scala.model.Indexes
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
@@ -26,6 +27,7 @@ import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.NrsSubmissionWorkItem
+import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.DateTimeService
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 import uk.gov.hmrc.mongo.workitem.WorkItem
@@ -41,11 +43,16 @@ class NRSWorkItemRepositoryItSpec
     with GuiceOneAppPerSuite {
 
   def servicesConfig: Map[String, String] = Map("mongodb.nrsSubmission.TTL" -> "5 seconds")
+  private lazy val dateTimeService = mock[DateTimeService]
 
   override def fakeApplication: Application =
     new GuiceApplicationBuilder()
       .configure(servicesConfig)
-      .overrides(bind[MongoComponent].toInstance(mongoComponent))
+      .overrides(
+        bind[MongoComponent].toInstance(mongoComponent),
+        bind[DateTimeService].toInstance(dateTimeService)
+      )
+
       .build()
 
   override protected val repository: NRSWorkItemRepository = app.injector.instanceOf[NRSWorkItemRepository]

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
@@ -29,6 +29,7 @@ import play.api.libs.concurrent.Futures
 import play.api.libs.json.Json
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.config.AppConfig
+import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnector.NrsCircuitBreaker
 import uk.gov.hmrc.excisemovementcontrolsystemapi.fixture.NrsTestData
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.nrs._
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.EmcsUtils
@@ -50,7 +51,8 @@ class NrsConnectorSpec extends PlaySpec with NrsTestData with EitherValues with 
   private val appConfig                  = mock[AppConfig]
   private val emcsUtils                  = mock[EmcsUtils]
   private val metrics                    = mock[MetricRegistry](RETURNS_DEEP_STUBS)
-  private val connector                  = new NrsConnector(httpClient, appConfig, metrics)
+  private val nrsCircuitBreaker = mock[NrsCircuitBreaker]
+  private val connector                  = new NrsConnector(httpClient, appConfig, metrics, nrsCircuitBreaker)
   private val timerContext               = mock[Timer.Context]
   private val timeStamp                  = ZonedDateTime.now()
   private val nrsUrl                     = "http://localhost:8080/nrs-url"

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
@@ -94,16 +94,6 @@ class NrsConnectorSpec extends PlaySpec with NrsTestData with EitherValues with 
     when(metrics.timer(any).time()) thenReturn timerContext
   }
 
-  "sendToNrs" should {
-    "return Done and call NRS" in {
-      val result = await(connector.sendToNrs(nrsPayLoad, "correlationId"))
-
-      result mustBe Done
-
-
-    }
-  }
-
   "submit OLD" should {
     "return Done" in {
       val result = await(connector.sendToNrsOld(nrsPayLoad, "correlationId"))

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
@@ -94,7 +94,17 @@ class NrsConnectorSpec extends PlaySpec with NrsTestData with EitherValues with 
     when(metrics.timer(any).time()) thenReturn timerContext
   }
 
-  "submit" should {
+  "sendToNrs" should {
+    "return Done and call NRS" in {
+      val result = await(connector.sendToNrs(nrsPayLoad, "correlationId"))
+
+      result mustBe Done
+
+
+    }
+  }
+
+  "submit OLD" should {
     "return Done" in {
       val result = await(connector.sendToNrsOld(nrsPayLoad, "correlationId"))
 

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
@@ -29,7 +29,6 @@ import play.api.libs.concurrent.Futures
 import play.api.libs.json.Json
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.excisemovementcontrolsystemapi.config.AppConfig
-import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnector.NrsCircuitBreaker
 import uk.gov.hmrc.excisemovementcontrolsystemapi.fixture.NrsTestData
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.nrs._
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.EmcsUtils
@@ -51,8 +50,7 @@ class NrsConnectorSpec extends PlaySpec with NrsTestData with EitherValues with 
   private val appConfig                  = mock[AppConfig]
   private val emcsUtils                  = mock[EmcsUtils]
   private val metrics                    = mock[MetricRegistry](RETURNS_DEEP_STUBS)
-  private val nrsCircuitBreaker = mock[NrsCircuitBreaker]
-  private val connector                  = new NrsConnector(httpClient, appConfig, metrics, nrsCircuitBreaker)
+  private val connector                  = new NrsConnector(httpClient, appConfig, metrics)
   private val timerContext               = mock[Timer.Context]
   private val timeStamp                  = ZonedDateTime.now()
   private val nrsUrl                     = "http://localhost:8080/nrs-url"

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/NrsSubmissionSchedulerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/NrsSubmissionSchedulerSpec.scala
@@ -37,15 +37,14 @@ import uk.gov.hmrc.excisemovementcontrolsystemapi.fixture.NrsTestData
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.nrs._
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.NRSWorkItemRepository
 import uk.gov.hmrc.excisemovementcontrolsystemapi.repository.model.NrsSubmissionWorkItem
-import uk.gov.hmrc.excisemovementcontrolsystemapi.services.NrsService
+import uk.gov.hmrc.excisemovementcontrolsystemapi.services.NrsServiceNew
 import uk.gov.hmrc.excisemovementcontrolsystemapi.utils.DateTimeService
-import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.mongo.workitem.ProcessingStatus.{Succeeded, ToDo}
-import uk.gov.hmrc.mongo.workitem.{ProcessingStatus, WorkItem}
+import uk.gov.hmrc.mongo.workitem.ProcessingStatus.ToDo
+import uk.gov.hmrc.mongo.workitem.WorkItem
 
-import java.time.{Instant, LocalDateTime, ZoneOffset, ZonedDateTime}
-import scala.concurrent.{ExecutionContext, Future}
+import java.time.{LocalDateTime, ZoneOffset}
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
 
 class NrsSubmissionSchedulerSpec
     extends AnyFreeSpec
@@ -59,7 +58,7 @@ class NrsSubmissionSchedulerSpec
   implicit val ec: ExecutionContext                              = ExecutionContext.global
   val mockNrsSubmissionWorkItemRepository: NRSWorkItemRepository = mock[NRSWorkItemRepository]
   val mockNrsConnector: NrsConnector                             = mock[NrsConnector]
-  val mockNrsService: NrsService                                 = mock[NrsService]
+  val mockNrsService: NrsServiceNew                              = mock[NrsServiceNew]
   val mockDateTimeService: DateTimeService                       = mock[DateTimeService]
   val appConfig: AppConfig                                       = app.injector.instanceOf[AppConfig]
 
@@ -67,7 +66,7 @@ class NrsSubmissionSchedulerSpec
     .overrides(
       bind[NRSWorkItemRepository].toInstance(mockNrsSubmissionWorkItemRepository),
       bind[NrsConnector].toInstance(mockNrsConnector),
-      bind[NrsService].toInstance(mockNrsService),
+      bind[NrsServiceNew].toInstance(mockNrsService),
       bind[DateTimeService].toInstance(mockDateTimeService)
     )
     .configure(

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/PushNotificationJobSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/PushNotificationJobSpec.scala
@@ -56,6 +56,9 @@ class PushNotificationJobSpec
     .configure(
       "scheduler.pushNotificationJob.initialDelay" -> "2 minutes",
       "scheduler.pushNotificationJob.interval"     -> "1 minute"
+//      "nrs.max-failures" -> 1,
+//      "nrs.reset-timeout" -> "1 second",
+//      "nrs.call-timeout" -> "30 seconds"
     )
     .build()
 

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceSpec.scala
@@ -120,7 +120,7 @@ class NrsServiceSpec extends PlaySpec with ScalaFutures with NrsTestData with Ei
   "submitNrs" should {
     "submit to NRS and call the repository to mark the workitem as done if it succeeds" in {
 
-      when(nrsConnector.sendToNrsOld(any(), any())(any())).thenReturn(Future.successful(Done))
+      when(nrsConnector.sendToNrs(any(), any())(any())).thenReturn(Future.successful(Done))
 
       when(nrsWorkItemRepository.complete(any, any())).thenReturn(Future(true))
 
@@ -128,7 +128,7 @@ class NrsServiceSpec extends PlaySpec with ScalaFutures with NrsTestData with Ei
 
       val result = await(service.submitNrs(testWorkItem))
 
-      verify(nrsConnector, times(1)).sendToNrsOld(testNrsPayload, testCorrelationId)
+      verify(nrsConnector, times(1)).sendToNrs(testNrsPayload, testCorrelationId)
 
       result mustBe Done
       verify(nrsWorkItemRepository).complete(testWorkItem.id, ProcessingStatus.Succeeded)


### PR DESCRIPTION
This PR adds some wiring for the scheduling of the NRS work, and also splits the connector and service so that the old and new functionality are entirely separate.
This still does not touch current prod behaviour.