### PR TITLE
Emcs 633 tidying

### DIFF
--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsCircuitBreakerProvider.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsCircuitBreakerProvider.scala
@@ -54,6 +54,9 @@ class NrsCircuitBreakerProvider @Inject() (
       .onOpen {
         logger.warn("NRS Circuit Breaker has opened")
       }
+      .onHalfOpen{
+        logger.warn("NRS Circuit Breaker set to half open")
+      }
       .onClose {
         logger.info("NRS Circuit Breaker has closed")
       }

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/NrsSubmissionScheduler.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/NrsSubmissionScheduler.scala
@@ -56,6 +56,9 @@ class NrsSubmissionScheduler @Inject() (
 
   override def interval: FiniteDuration = configuration.get[FiniteDuration]("scheduler.nrsSubmissionJob.interval")
 
+  override val numberOfInstances: Int =
+    configuration.get[Int]("scheduler.nrsSubmissionJob.numberOfInstances")
+
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
 }

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceNew.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceNew.scala
@@ -20,7 +20,6 @@ import org.apache.pekko.Done
 import play.api.Logging
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve._
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.excisemovementcontrolsystemapi.connectors.NrsConnectorNew
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.auth.ParsedXmlRequest
 import uk.gov.hmrc.excisemovementcontrolsystemapi.models.nrs._

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceNew.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceNew.scala
@@ -47,10 +47,9 @@ class NrsServiceNew @Inject() (
     extends AuthorisedFunctions
     with Logging {
 
-  def makeNrsWorkItemAndAddToRepository(
+  def makeWorkItemAndQueue(
     request: ParsedXmlRequest[_],
-    authorisedErn: String,
-    correlationId: String
+    authorisedErn: String
   )(implicit headerCarrier: HeaderCarrier): Future[Done] = {
 
     val payload        = request.body.toString

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -118,18 +118,24 @@ scheduler {
     lock-ttl = 45 seconds
   }
 
-  movementsCorrectingJob{
+  movementsCorrectingJob {
     initialDelay = 1 minutes
     interval = 1 minutes
     numberOfInstances = 1
     maxRetries = 3
   }
 
-  miscodedMovementsCorrectingJob{
+  miscodedMovementsCorrectingJob {
     initialDelay = 1 minutes
     interval = 1 minutes
     numberOfInstances = 1
     maxRetries = 3
+  }
+
+  nrsSubmissionJob {
+      initialDelay = 1 minutes
+      interval = 1 minutes
+      numberOfInstances = 1
   }
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -184,6 +184,8 @@ microservice {
       max-failures = 10
       call-timeout = 30 seconds
       reset-timeout = 10 minutes
+      max-reset-timeout = 30 minutes
+      exponential-backoff-factor = 2.0
     }
 
     push-pull-notifications {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -133,8 +133,8 @@ scheduler {
   }
 
   nrsSubmissionJob {
-      initialDelay = 1 minutes
-      interval = 1 minutes
+      initialDelay = 1 second
+      interval = 1 second
       numberOfInstances = 1
   }
 }

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorSpec.scala
@@ -53,7 +53,9 @@ class NrsConnectorSpec
         "microservice.services.nrs.api-key" -> "some-bearer",
         "microservice.services.nrs.max-failures" -> 1,
         "microservice.services.nrs.reset-timeout" -> "1 second",
-        "microservice.services.nrs.call-timeout" -> "30 seconds"
+        "microservice.services.nrs.call-timeout" -> "30 seconds",
+        "microservice.services.nrs.max-reset-timeout" -> "30 seconds",
+        "microservice.services.nrs.exponential-backoff-factor" -> 2.0
       )
       .build()
 

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/NrsSubmissionSchedulerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/scheduling/NrsSubmissionSchedulerSpec.scala
@@ -70,9 +70,10 @@ class NrsSubmissionSchedulerSpec
       bind[DateTimeService].toInstance(mockDateTimeService)
     )
     .configure(
-      "scheduler.nrsSubmissionJob.initialDelay" -> "1 minutes",
-      "scheduler.nrsSubmissionJob.interval"     -> "1 minute",
-      "featureFlags.nrsSubmissionEnabled"       -> true
+      "scheduler.nrsSubmissionJob.initialDelay"      -> "1 minutes",
+      "scheduler.nrsSubmissionJob.interval"          -> "1 minute",
+      "scheduler.nrsSubmissionJob.numberOfInstances" -> 1,
+      "featureFlags.nrsSubmissionEnabled"            -> true
     )
     .build()
 
@@ -115,7 +116,9 @@ class NrsSubmissionSchedulerSpec
     "use interval from configuration" in {
       nrsSubmissionScheduler.interval mustBe FiniteDuration(1, "minute")
     }
-
+    "use the correct number of instances from configuration" in {
+      nrsSubmissionScheduler.numberOfInstances mustBe 1
+    }
     "submit to NRS when there is an outstanding nrs workitem to process" in {
 
       val workItem = WorkItem(

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceNewSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceNewSpec.scala
@@ -108,7 +108,7 @@ class NrsServiceNewSpec extends PlaySpec with ScalaFutures with NrsTestData with
           )
         )
 
-      val result = await(service.makeNrsWorkItemAndAddToRepository(testRequest, "ern", "correlationId")(hc))
+      val result = await(service.makeWorkItemAndQueue(testRequest, "ern", "correlationId")(hc))
 
       verify(nrsWorkItemRepository).pushNew(NrsSubmissionWorkItem(testNrsPayload))
       result mustBe Done

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceNewSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceNewSpec.scala
@@ -108,7 +108,7 @@ class NrsServiceNewSpec extends PlaySpec with ScalaFutures with NrsTestData with
           )
         )
 
-      val result = await(service.makeWorkItemAndQueue(testRequest, "ern", "correlationId")(hc))
+      val result = await(service.makeWorkItemAndQueue(testRequest, "ern")(hc))
 
       verify(nrsWorkItemRepository).pushNew(NrsSubmissionWorkItem(testNrsPayload))
       result mustBe Done


### PR DESCRIPTION
This Pr:
Tidies code, renamed method that had a messy name
Adds config to correctly limit to running one instance of the scheduled job per instance of the service. (Still figuring out how the actual throttling will work...)
Adds exponential backoff to the circuit breaker and config for that.