### PR TITLE
Remove completed nrs workitems

### DIFF
--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceNew.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceNew.scala
@@ -101,7 +101,7 @@ class NrsServiceNew @Inject() (
       .sendToNrs(workItem.item.payload, correlationIdService.generateCorrelationId())
       .flatMap { _ =>
         nrsWorkItemRepository
-          .complete(workItem.id, Succeeded)
+          .completeAndDelete(workItem.id)
           .map(_ => Done)
       }
       .recoverWith {
@@ -182,7 +182,7 @@ class NrsServiceNew @Inject() (
       .map {
         _.getOrElse {
           logger.info(
-            s"Could not acquire lock on nrsWorkItemRepository for thing"
+            s"Could not acquire lock on nrsWorkItemRepository"
           )
           Done
         }

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorNewSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/connectors/NrsConnectorNewSpec.scala
@@ -73,7 +73,7 @@ class NrsConnectorNewSpec
       identityData = testNrsIdentityData,
       userAuthToken = testAuthToken,
       headerData = Map(),
-      searchKeys = Map("ern" -> "123")
+      searchKeys = Map("ern" -> "ERN123")
     )
     val nrsPayLoad                 = NrsPayload("encodepayload", nrsMetadata)
 

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceNewSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/NrsServiceNewSpec.scala
@@ -157,14 +157,14 @@ class NrsServiceNewSpec
 
       when(mockNrsConnectorNew.sendToNrs(any(), any())(any())).thenReturn(Future.successful(Done))
 
-      when(mockNrsWorkItemRepository.complete(any, any())).thenReturn(Future(true))
+      when(mockNrsWorkItemRepository.completeAndDelete(any)).thenReturn(Future(true))
 
       val result = await(service.submitNrs(testWorkItem))
 
       verify(mockNrsConnectorNew, times(1)).sendToNrs(testNrsPayload, testCorrelationId)
 
       result mustBe Done
-      verify(mockNrsWorkItemRepository).complete(testWorkItem.id, Succeeded)
+      verify(mockNrsWorkItemRepository).completeAndDelete(testWorkItem.id)
     }
     "mark the workItem as failed if submission fails with 5xx" in {
       when(mockNrsConnectorNew.sendToNrs(any(), any())(any()))
@@ -211,12 +211,12 @@ class NrsServiceNewSpec
 
       when(mockNrsWorkItemRepository.pullOutstanding(any(), any()))
         .thenReturn(Future.successful(Some(testWorkItem)))
-      when(mockNrsWorkItemRepository.complete(any, any())).thenReturn(Future(true))
+      when(mockNrsWorkItemRepository.completeAndDelete(any)).thenReturn(Future(true))
 
       val result = await(service.processSingleNrs())
 
       verify(mockNrsConnectorNew, times(1)).sendToNrs(testNrsPayload, testCorrelationId)
-      verify(mockNrsWorkItemRepository).complete(testWorkItem.id, Succeeded)
+      verify(mockNrsWorkItemRepository).completeAndDelete(testWorkItem.id)
       result mustBe true
     }
     "call to submit the NRS data and return true if it tried to process a thing but failed" in {
@@ -266,7 +266,7 @@ class NrsServiceNewSpec
     "if the connector call takes less than 1 second to finish, should take at least 1 second to finish" in {
 
       when(mockNrsConnectorNew.sendToNrs(any(), any())(any())).thenReturn(Future.successful(Done))
-      when(mockNrsWorkItemRepository.complete(any, any())).thenReturn(Future(true))
+      when(mockNrsWorkItemRepository.completeAndDelete(any)).thenReturn(Future(true))
 
       val timeBefore = System.currentTimeMillis
       service.submitNrsThrottled(testWorkItem).futureValue
@@ -283,7 +283,7 @@ class NrsServiceNewSpec
         Done
       }
       when(mockNrsConnectorNew.sendToNrs(any(), any())(any())).thenReturn(future)
-      when(mockNrsWorkItemRepository.complete(any, any())).thenReturn(Future(true))
+      when(mockNrsWorkItemRepository.completeAndDelete(any)).thenReturn(Future(true))
 
       val timeBefore = System.currentTimeMillis
       service.submitNrsThrottled(testWorkItem).futureValue


### PR DESCRIPTION
Changes to use complete and delete, so that the workitems are removed from the repository once they are successfully sent to nrs.