### PR TITLE
CS-7113: Don't use consignee ID when filtering for draft movements

### DIFF
--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/DraftExciseMovementController.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/DraftExciseMovementController.scala
@@ -65,10 +65,10 @@ class DraftExciseMovementController @Inject() (
         ie815Message  <- getIe815Message(request.ieMessage)
         authorisedErn <- validateMessage(ie815Message, request.erns)
         clientId      <- retrieveClientIdFromHeader(request)
-        boxId         <- getBoxId(clientId)
+        maybeBoxId    <- getBoxId(clientId)
         _             <- submitAndHandleError(request, authorisedErn, ie815Message)
-        movement      <- saveMovement(boxId, ie815Message, request)
-      } yield (movement, boxId, ie815Message)).fold[Result](
+        movement      <- getDraftOrSaveNew(maybeBoxId, ie815Message, request)
+      } yield (movement, maybeBoxId, ie815Message)).fold[Result](
         failResult => failResult,
         success => {
           val (movement, boxId, ie815Message) = success
@@ -130,17 +130,17 @@ class DraftExciseMovementController @Inject() (
       messageValidator.convertErrorToResponse(x, dateTimeService.timestamp())
     })
 
-  private def saveMovement(
-    boxId: Option[String],
+  private def getDraftOrSaveNew(
+    maybeBoxId: Option[String],
     message: IE815Message,
     request: ParsedXmlRequest[NodeSeq]
   )(implicit hc: HeaderCarrier): EitherT[Future, Result, Movement] =
     EitherT {
 
-      val newMovement: Movement = createMovementFomMessage(message, boxId)
-      boxId.map(boxIdRepository.save(newMovement.consignorId, _))
+      val unsavedMovement: Movement = createMovementFomMessage(message, maybeBoxId)
+      maybeBoxId.foreach(boxIdRepository.save(unsavedMovement.consignorId, _))
 
-      movementMessageService.saveNewMovement(newMovement).map {
+      movementMessageService.getDraftMovementOrSaveNew(unsavedMovement).map {
         case Left(result)    =>
           if (appConfig.oldAuditingEnabled) auditService.auditMessage(message, "Failed to Save")
           auditService.messageSubmittedNoMovement(message, true, message.correlationId, request)

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
@@ -70,7 +70,10 @@ class MovementRepository @Inject() (
       Some(equal("consignorId", movement.consignorId)),
       Some(equal("localReferenceNumber", movement.localReferenceNumber)),
       Some(not(exists("administrativeReferenceCode"))),
-      movement.consigneeId.map(consignee => equal("consigneeId", consignee))
+      // consigneeId is not included here
+      // This should make it match the duplication checking logic in Core so we
+      // don't have the problem where movements are saved successfully by Core
+      // and then rejected as being duplicates by EMCS API - for more info see CS-6769
     )
     collection
       .find(

--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementService.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementService.scala
@@ -42,12 +42,12 @@ class MovementService @Inject() (
 )(implicit ec: ExecutionContext)
     extends Logging {
 
-  def saveNewMovement(movement: Movement)(implicit hc: HeaderCarrier): Future[Either[Result, Movement]] =
+  def getDraftMovementOrSaveNew(newMovement: Movement)(implicit hc: HeaderCarrier): Future[Either[Result, Movement]] =
     movementRepository
-      .findDraftMovement(movement)
-      .flatMap { draftMovement =>
-        draftMovement.map(movement => Future.successful(Right(movement))).getOrElse {
-          saveMovement(movement).map(_ => Right(movement))
+      .findDraftMovement(newMovement)
+      .flatMap { maybeDraftMovement =>
+        maybeDraftMovement.map(draftMovement => Future.successful(Right(draftMovement))).getOrElse {
+          saveMovement(newMovement).map(_ => Right(newMovement))
         }
       }
       .recover {
@@ -55,7 +55,7 @@ class MovementService @Inject() (
           logger.warn(
             s"[MovementService] - The local reference number has already been used for another movement"
           )
-          createDuplicateErrorResponse(movement)
+          Left(createDuplicateErrorResponse(newMovement))
         case NonFatal(e)              =>
           logger.error(s"[MovementService] - Error occurred while saving movement, ${e.getMessage}", e)
           Left(
@@ -72,7 +72,7 @@ class MovementService @Inject() (
       }
 
   def saveMovement(
-    updatedMovement: Movement,
+    movement: Movement,
     jobId: Option[String] = None,
     batchId: Option[String] = None,
     messagesAlreadyInMongo: Seq[Message] = Seq.empty
@@ -83,16 +83,16 @@ class MovementService @Inject() (
     val messagesAlreadyInMongoMap = messagesAlreadyInMongo.map(p => p.messageId -> p).toMap
 
     val newMessages =
-      updatedMovement.messages.filter(p1 => !messagesAlreadyInMongoMap.get(p1.messageId).contains(p1))
+      movement.messages.filter(p1 => !messagesAlreadyInMongoMap.get(p1.messageId).contains(p1))
 
     movementRepository
-      .saveMovement(updatedMovement)
+      .saveMovement(movement)
       .map { _ =>
-        auditService.movementSavedSuccess(updatedMovement, batchId, jobId, newMessages)
+        auditService.movementSavedSuccess(movement, batchId, jobId, newMessages)
         Done
       }
       .recoverWith { case e =>
-        auditService.movementSavedFailure(updatedMovement, e.getMessage, batchId, jobId, newMessages)
+        auditService.movementSavedFailure(movement, e.getMessage, batchId, jobId, newMessages)
         Future.failed(e)
       }
   }
@@ -128,15 +128,13 @@ class MovementService @Inject() (
       }
     }
 
-  private def createDuplicateErrorResponse(movement: Movement): Either[Result, Movement] =
-    Left(
-      BadRequest(
-        Json.toJson(
-          ErrorResponse(
-            dateTimeService.timestamp(),
-            "Duplicate LRN error",
-            s"The local reference number ${movement.localReferenceNumber} has already been used for another movement"
-          )
+  private def createDuplicateErrorResponse(movement: Movement): Result =
+    BadRequest(
+      Json.toJson(
+        ErrorResponse(
+          dateTimeService.timestamp(),
+          "Duplicate LRN error",
+          s"The local reference number ${movement.localReferenceNumber} has already been used for another movement"
         )
       )
     )

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
@@ -68,7 +68,7 @@ class MovementRepositoryItSpec
     when(dateTimeService.timestamp()).thenReturn(timestamp)
   }
 
-  "saveMovement" should {
+  "upsertMovement" should {
 
     val uuid     = UUID.randomUUID()
     val movement = Movement(uuid.toString, Some("boxId"), "123", "345", Some("789"), None, timestamp, Seq.empty)
@@ -244,11 +244,11 @@ class MovementRepositoryItSpec
 
       result mustBe None
     }
-    "return None if matching LRN and consignor but has different consignee" in {
+    "do not include consigneeId when trying to see if a draft movement exists (this matches the duplication checking logic in Core)" in {
       insertMovement(movementDiffConsignee)
       val result = repository.findDraftMovement(movement).futureValue
 
-      result mustBe None
+      result mustBe Some(movementDiffConsignee)
     }
     "return the existing movement matching the consignor, consignee and LRN with no ARC" in {
       insertMovement(movement)

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageServiceItSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageServiceItSpec.scala
@@ -264,7 +264,7 @@ class MessageServiceItSpec
 
       when(mockTraderMovementConnector.getMovementMessages(any, any)(any)).thenReturn(Future.successful(messages))
 
-      movementService.saveNewMovement(initialMovement).futureValue.isRight mustBe true
+      movementService.getDraftMovementOrSaveNew(initialMovement).futureValue.isRight mustBe true
       service.updateMessages(consignorErn, None)(hc).futureValue
 
       val result = repository.getMovementByLRNAndERNIn(lrn, List(consignorErn)).futureValue
@@ -321,7 +321,7 @@ class MessageServiceItSpec
       when(mockMessageConnector.acknowledgeMessages(any, any, any)(any))
         .thenReturn(Future.successful(acknowledgeResponse))
 
-      movementService.saveNewMovement(initialMovement)(hc).futureValue.isRight mustBe true
+      movementService.getDraftMovementOrSaveNew(initialMovement)(hc).futureValue.isRight mustBe true
       service.updateMessages(consigneeErn, None)(hc).futureValue
 
       val result = repository.getMovementByLRNAndERNIn(lrn, List(consignorErn)).futureValue

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/DraftExciseMovementControllerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/DraftExciseMovementControllerSpec.scala
@@ -113,7 +113,7 @@ class DraftExciseMovementControllerSpec
     "return 202" when {
 
       "push pull notifications feature flag is enabled" in {
-        when(movementService.saveNewMovement(any)(any))
+        when(movementService.getDraftMovementOrSaveNew(any)(any))
           .thenReturn(
             Future.successful(Right(Movement(Some(defaultBoxId), "123", consignorId, Some("789"), None, Instant.now)))
           )
@@ -134,7 +134,7 @@ class DraftExciseMovementControllerSpec
 
         withClue("should save the new movement") {
           val captor      = ArgCaptor[Movement]
-          verify(movementService).saveNewMovement(captor.capture)(any)
+          verify(movementService).getDraftMovementOrSaveNew(captor.capture)(any)
           val newMovement = captor.value
           newMovement.localReferenceNumber mustBe "123"
           newMovement.consignorId mustBe consignorId
@@ -148,7 +148,7 @@ class DraftExciseMovementControllerSpec
       "push pull notifications feature flag is disabled" in {
         when(appConfig.pushNotificationsEnabled).thenReturn(false)
 
-        when(movementService.saveNewMovement(any)(any))
+        when(movementService.getDraftMovementOrSaveNew(any)(any))
           .thenReturn(
             Future.successful(Right(Movement(Some(defaultBoxId), "123", consignorId, Some("789"), None, Instant.now)))
           )
@@ -163,7 +163,7 @@ class DraftExciseMovementControllerSpec
 
         withClue("should save the new movement with no box id") {
           val captor      = ArgCaptor[Movement]
-          verify(movementService).saveNewMovement(captor.capture)(any)
+          verify(movementService).getDraftMovementOrSaveNew(captor.capture)(any)
           val newMovement = captor.value
           newMovement.boxId mustBe None
         }
@@ -172,7 +172,7 @@ class DraftExciseMovementControllerSpec
     }
 
     "pass the Client Box id to notification service when is present" in {
-      when(movementService.saveNewMovement(any)(any))
+      when(movementService.getDraftMovementOrSaveNew(any)(any))
         .thenReturn(
           Future.successful(Right(Movement(Some(defaultBoxId), "123", consignorId, Some("789"), None, Instant.now)))
         )
@@ -184,7 +184,7 @@ class DraftExciseMovementControllerSpec
     }
 
     "sends expected audit events" in {
-      when(movementService.saveNewMovement(any)(any))
+      when(movementService.getDraftMovementOrSaveNew(any)(any))
         .thenReturn(
           Future.successful(Right(Movement(Some(defaultBoxId), "123", consignorId, Some("789"), None, Instant.now)))
         )
@@ -215,7 +215,7 @@ class DraftExciseMovementControllerSpec
     }
 
     "sends failure audits when a message submits but doesn't save" in {
-      when(movementService.saveNewMovement(any)(any)).thenReturn(Future.successful(Left(BadRequest(""))))
+      when(movementService.getDraftMovementOrSaveNew(any)(any)).thenReturn(Future.successful(Left(BadRequest(""))))
       when(appConfig.oldAuditingEnabled).thenReturn(true)
 
       await(createWithSuccessfulAuth.submit(request))
@@ -227,7 +227,7 @@ class DraftExciseMovementControllerSpec
     }
 
     "adds the boxId to the BoxIdRepository for consignor" in {
-      when(movementService.saveNewMovement(any)(any))
+      when(movementService.getDraftMovementOrSaveNew(any)(any))
         .thenReturn(Future.successful(Right(Movement(Some(defaultBoxId), "lrn", consignorId, None))))
 
       await(createWithSuccessfulAuth.submit(request))
@@ -309,7 +309,7 @@ class DraftExciseMovementControllerSpec
       }
 
       "cannot save the movement" in {
-        when(movementService.saveNewMovement(any)(any))
+        when(movementService.getDraftMovementOrSaveNew(any)(any))
           .thenReturn(Future.successful(Left(InternalServerError("error"))))
 
         val result = createWithSuccessfulAuth.submit(request)
@@ -318,7 +318,7 @@ class DraftExciseMovementControllerSpec
       }
 
       "XML is not a IE815 message" in {
-        when(movementService.saveNewMovement(any)(any))
+        when(movementService.getDraftMovementOrSaveNew(any)(any))
           .thenReturn(
             Future.successful(Right(Movement(Some(defaultBoxId), "123", "456", Some("789"), None, Instant.now)))
           )

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementServiceSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementServiceSpec.scala
@@ -85,7 +85,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
   private val exampleMovement: Movement =
     Movement(Some("boxId"), lrn, consignorId, Some(consigneeId), messages = Seq(exampleMessage))
 
-  "saveNewMovement" should {
+  "getDraftMovementOrSaveNew" should {
     "return a Movement" in {
       val successMovement = exampleMovement
       when(mockMovementRepository.findDraftMovement(any))
@@ -94,7 +94,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.saveMovement(any))
         .thenReturn(Future.successful(Done))
 
-      val result = await(movementService.saveNewMovement(successMovement))
+      val result = await(movementService.getDraftMovementOrSaveNew(successMovement))
 
       result mustBe Right(successMovement)
     }
@@ -106,7 +106,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.saveMovement(any))
         .thenReturn(Future.failed(new RuntimeException("error")))
 
-      val result = await(movementService.saveNewMovement(exampleMovement))
+      val result = await(movementService.getDraftMovementOrSaveNew(exampleMovement))
 
       val expectedError = ErrorResponse(testDateTime, "Database error", "error")
       result.left.value mustBe InternalServerError(Json.toJson(expectedError))
@@ -122,7 +122,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
           )
         )
 
-      val result = await(movementService.saveNewMovement(exampleMovement))
+      val result = await(movementService.getDraftMovementOrSaveNew(exampleMovement))
 
       val expectedError = ErrorResponse(
         testDateTime,
@@ -138,7 +138,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.saveMovement(any))
         .thenReturn(Future.successful(Done))
 
-      val result = await(movementService.saveNewMovement(exampleMovement))
+      val result = await(movementService.getDraftMovementOrSaveNew(exampleMovement))
 
       val expectedError = ErrorResponse(testDateTime, "Database error", "Database error")
       result.left.value mustBe InternalServerError(Json.toJson(expectedError))
@@ -151,7 +151,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.saveMovement(any))
         .thenReturn(Future.successful(Done))
 
-      val result = await(movementService.saveNewMovement(exampleMovement))
+      val result = await(movementService.getDraftMovementOrSaveNew(exampleMovement))
 
       result mustBe Right(exampleMovement)
     }


### PR DESCRIPTION
This should make it match the duplication checking logic in Core so we don't have the problem where movements are saved successfully by Core and then rejected as being duplicates by EMCS API

Also, rename some functions and values to describe them better, and some minor refactoring