### PR TITLE
Revert "CS-6769: Don't use consignee ID when filtering for draft movements"

### DIFF
--- a/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
+++ b/app/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepository.scala
@@ -70,10 +70,7 @@ class MovementRepository @Inject() (
       Some(equal("consignorId", movement.consignorId)),
       Some(equal("localReferenceNumber", movement.localReferenceNumber)),
       Some(not(exists("administrativeReferenceCode"))),
-      // consigneeId is not included here
-      // This should make it match the duplication checking logic in Core so we
-      // don't have the problem where movements are saved successfully by Core
-      // and then rejected as being duplicates by EMCS API - for more info see CS-6769
+      movement.consigneeId.map(consignee => equal("consigneeId", consignee))
     )
     collection
       .find(

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/repository/MovementRepositoryItSpec.scala
@@ -68,7 +68,7 @@ class MovementRepositoryItSpec
     when(dateTimeService.timestamp()).thenReturn(timestamp)
   }
 
-  "upsertMovement" should {
+  "saveMovement" should {
 
     val uuid     = UUID.randomUUID()
     val movement = Movement(uuid.toString, Some("boxId"), "123", "345", Some("789"), None, timestamp, Seq.empty)
@@ -244,11 +244,11 @@ class MovementRepositoryItSpec
 
       result mustBe None
     }
-    "do not include consigneeId when trying to see if a draft movement exists (this matches the duplication checking logic in Core)" in {
+    "return None if matching LRN and consignor but has different consignee" in {
       insertMovement(movementDiffConsignee)
       val result = repository.findDraftMovement(movement).futureValue
 
-      result mustBe Some(movementDiffConsignee)
+      result mustBe None
     }
     "return the existing movement matching the consignor, consignee and LRN with no ARC" in {
       insertMovement(movement)

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageServiceItSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MessageServiceItSpec.scala
@@ -264,7 +264,7 @@ class MessageServiceItSpec
 
       when(mockTraderMovementConnector.getMovementMessages(any, any)(any)).thenReturn(Future.successful(messages))
 
-      movementService.getDraftMovementOrSaveNew(initialMovement).futureValue.isRight mustBe true
+      movementService.saveNewMovement(initialMovement).futureValue.isRight mustBe true
       service.updateMessages(consignorErn, None)(hc).futureValue
 
       val result = repository.getMovementByLRNAndERNIn(lrn, List(consignorErn)).futureValue
@@ -321,7 +321,7 @@ class MessageServiceItSpec
       when(mockMessageConnector.acknowledgeMessages(any, any, any)(any))
         .thenReturn(Future.successful(acknowledgeResponse))
 
-      movementService.getDraftMovementOrSaveNew(initialMovement)(hc).futureValue.isRight mustBe true
+      movementService.saveNewMovement(initialMovement)(hc).futureValue.isRight mustBe true
       service.updateMessages(consigneeErn, None)(hc).futureValue
 
       val result = repository.getMovementByLRNAndERNIn(lrn, List(consignorErn)).futureValue

--- a/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementServiceItSpec.scala
+++ b/it/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementServiceItSpec.scala
@@ -66,7 +66,7 @@ class MovementServiceItSpec
     when(dateTimeService.timestamp()).thenReturn(timestamp)
   }
 
-  "getDraftMovementOrSaveNew" should {
+  "saveNewMovement" should {
     val lrn            = "123"
     val consignorId    = "Abc"
     val consigneeId    = "def"
@@ -82,7 +82,7 @@ class MovementServiceItSpec
     "throw an error when LRN is already in database for consignor with an ARC" in {
       insert(withArc).futureValue
 
-      val result = movementService.getDraftMovementOrSaveNew(movement).futureValue
+      val result = movementService.saveNewMovement(movement).futureValue
 
       val expectedError = ErrorResponse(
         timestamp,
@@ -92,18 +92,23 @@ class MovementServiceItSpec
       result.left.value mustBe BadRequest(Json.toJson(expectedError))
     }
 
-    "return the newly saved movement even if the consigneeId is different (this matches the duplication checking logic in Core)" in {
+    "throw an error when LRN is already in database with no ARC for same consignor but different consignee" in {
       insert(diffConsignee).futureValue
 
-      val result = movementService.getDraftMovementOrSaveNew(movement).futureValue
+      val result = movementService.saveNewMovement(movement).futureValue
 
-      result mustBe Right(diffConsignee)
+      val expectedError = ErrorResponse(
+        timestamp,
+        "Duplicate LRN error",
+        "The local reference number 123 has already been used for another movement"
+      )
+      result.left.value mustBe BadRequest(Json.toJson(expectedError))
     }
 
     "return the newly saved movement when LRN is already in database for different consignor but same consignee" in {
       insert(diffConsignor).futureValue
 
-      val result = movementService.getDraftMovementOrSaveNew(movement).futureValue
+      val result = movementService.saveNewMovement(movement).futureValue
 
       result mustBe Right(movement)
     }
@@ -111,7 +116,7 @@ class MovementServiceItSpec
     "return the newly saved movement when LRN is already in database as a consignee and it is submitted as a consignor" in {
       insert(switched).futureValue
 
-      val result = movementService.getDraftMovementOrSaveNew(movement).futureValue
+      val result = movementService.saveNewMovement(movement).futureValue
 
       result mustBe Right(movement)
     }

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/DraftExciseMovementControllerSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/controllers/DraftExciseMovementControllerSpec.scala
@@ -113,7 +113,7 @@ class DraftExciseMovementControllerSpec
     "return 202" when {
 
       "push pull notifications feature flag is enabled" in {
-        when(movementService.getDraftMovementOrSaveNew(any)(any))
+        when(movementService.saveNewMovement(any)(any))
           .thenReturn(
             Future.successful(Right(Movement(Some(defaultBoxId), "123", consignorId, Some("789"), None, Instant.now)))
           )
@@ -134,7 +134,7 @@ class DraftExciseMovementControllerSpec
 
         withClue("should save the new movement") {
           val captor      = ArgCaptor[Movement]
-          verify(movementService).getDraftMovementOrSaveNew(captor.capture)(any)
+          verify(movementService).saveNewMovement(captor.capture)(any)
           val newMovement = captor.value
           newMovement.localReferenceNumber mustBe "123"
           newMovement.consignorId mustBe consignorId
@@ -148,7 +148,7 @@ class DraftExciseMovementControllerSpec
       "push pull notifications feature flag is disabled" in {
         when(appConfig.pushNotificationsEnabled).thenReturn(false)
 
-        when(movementService.getDraftMovementOrSaveNew(any)(any))
+        when(movementService.saveNewMovement(any)(any))
           .thenReturn(
             Future.successful(Right(Movement(Some(defaultBoxId), "123", consignorId, Some("789"), None, Instant.now)))
           )
@@ -163,7 +163,7 @@ class DraftExciseMovementControllerSpec
 
         withClue("should save the new movement with no box id") {
           val captor      = ArgCaptor[Movement]
-          verify(movementService).getDraftMovementOrSaveNew(captor.capture)(any)
+          verify(movementService).saveNewMovement(captor.capture)(any)
           val newMovement = captor.value
           newMovement.boxId mustBe None
         }
@@ -172,7 +172,7 @@ class DraftExciseMovementControllerSpec
     }
 
     "pass the Client Box id to notification service when is present" in {
-      when(movementService.getDraftMovementOrSaveNew(any)(any))
+      when(movementService.saveNewMovement(any)(any))
         .thenReturn(
           Future.successful(Right(Movement(Some(defaultBoxId), "123", consignorId, Some("789"), None, Instant.now)))
         )
@@ -184,7 +184,7 @@ class DraftExciseMovementControllerSpec
     }
 
     "sends expected audit events" in {
-      when(movementService.getDraftMovementOrSaveNew(any)(any))
+      when(movementService.saveNewMovement(any)(any))
         .thenReturn(
           Future.successful(Right(Movement(Some(defaultBoxId), "123", consignorId, Some("789"), None, Instant.now)))
         )
@@ -215,7 +215,7 @@ class DraftExciseMovementControllerSpec
     }
 
     "sends failure audits when a message submits but doesn't save" in {
-      when(movementService.getDraftMovementOrSaveNew(any)(any)).thenReturn(Future.successful(Left(BadRequest(""))))
+      when(movementService.saveNewMovement(any)(any)).thenReturn(Future.successful(Left(BadRequest(""))))
       when(appConfig.oldAuditingEnabled).thenReturn(true)
 
       await(createWithSuccessfulAuth.submit(request))
@@ -227,7 +227,7 @@ class DraftExciseMovementControllerSpec
     }
 
     "adds the boxId to the BoxIdRepository for consignor" in {
-      when(movementService.getDraftMovementOrSaveNew(any)(any))
+      when(movementService.saveNewMovement(any)(any))
         .thenReturn(Future.successful(Right(Movement(Some(defaultBoxId), "lrn", consignorId, None))))
 
       await(createWithSuccessfulAuth.submit(request))
@@ -309,7 +309,7 @@ class DraftExciseMovementControllerSpec
       }
 
       "cannot save the movement" in {
-        when(movementService.getDraftMovementOrSaveNew(any)(any))
+        when(movementService.saveNewMovement(any)(any))
           .thenReturn(Future.successful(Left(InternalServerError("error"))))
 
         val result = createWithSuccessfulAuth.submit(request)
@@ -318,7 +318,7 @@ class DraftExciseMovementControllerSpec
       }
 
       "XML is not a IE815 message" in {
-        when(movementService.getDraftMovementOrSaveNew(any)(any))
+        when(movementService.saveNewMovement(any)(any))
           .thenReturn(
             Future.successful(Right(Movement(Some(defaultBoxId), "123", "456", Some("789"), None, Instant.now)))
           )

--- a/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementServiceSpec.scala
+++ b/test/uk/gov/hmrc/excisemovementcontrolsystemapi/services/MovementServiceSpec.scala
@@ -85,7 +85,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
   private val exampleMovement: Movement =
     Movement(Some("boxId"), lrn, consignorId, Some(consigneeId), messages = Seq(exampleMessage))
 
-  "getDraftMovementOrSaveNew" should {
+  "saveNewMovement" should {
     "return a Movement" in {
       val successMovement = exampleMovement
       when(mockMovementRepository.findDraftMovement(any))
@@ -94,7 +94,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.saveMovement(any))
         .thenReturn(Future.successful(Done))
 
-      val result = await(movementService.getDraftMovementOrSaveNew(successMovement))
+      val result = await(movementService.saveNewMovement(successMovement))
 
       result mustBe Right(successMovement)
     }
@@ -106,7 +106,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.saveMovement(any))
         .thenReturn(Future.failed(new RuntimeException("error")))
 
-      val result = await(movementService.getDraftMovementOrSaveNew(exampleMovement))
+      val result = await(movementService.saveNewMovement(exampleMovement))
 
       val expectedError = ErrorResponse(testDateTime, "Database error", "error")
       result.left.value mustBe InternalServerError(Json.toJson(expectedError))
@@ -122,7 +122,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
           )
         )
 
-      val result = await(movementService.getDraftMovementOrSaveNew(exampleMovement))
+      val result = await(movementService.saveNewMovement(exampleMovement))
 
       val expectedError = ErrorResponse(
         testDateTime,
@@ -138,7 +138,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.saveMovement(any))
         .thenReturn(Future.successful(Done))
 
-      val result = await(movementService.getDraftMovementOrSaveNew(exampleMovement))
+      val result = await(movementService.saveNewMovement(exampleMovement))
 
       val expectedError = ErrorResponse(testDateTime, "Database error", "Database error")
       result.left.value mustBe InternalServerError(Json.toJson(expectedError))
@@ -151,7 +151,7 @@ class MovementServiceSpec extends PlaySpec with EitherValues with BeforeAndAfter
       when(mockMovementRepository.saveMovement(any))
         .thenReturn(Future.successful(Done))
 
-      val result = await(movementService.getDraftMovementOrSaveNew(exampleMovement))
+      val result = await(movementService.saveNewMovement(exampleMovement))
 
       result mustBe Right(exampleMovement)
     }


### PR DESCRIPTION
Reverts hmrc/excise-movement-control-system-api#309