### PR TITLE
Enable FS4.2 by default

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -134,7 +134,7 @@ featureFlags {
   processingAuditingEnabled = true
   oldAuditingEnabled = false
   protectionFilterEnabled = true
-  latestFunctionalSpecEnabled = false
+  latestFunctionalSpecEnabled = true
   transformJobEnabled = false
   runV1Validation  = false
   pollingNewMessagesEnabled = true


### PR DESCRIPTION
Sets the `latestFunctionalSpecEnabled` feature flag to `true`, since it's already enabled in all user-facing environments